### PR TITLE
ci: use node v16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '12.x'
+          node-version: '16.x'
       - name: Install dependencies
         run: npm install
       - name: Lint files
@@ -28,9 +28,9 @@ jobs:
         node: [17.x, 16.x, 14.x, 12.x, "12.22.0"]
         include:
         - os: windows-latest
-          node: "12.x"
+          node: "16.x"
         - os: macOS-latest
-          node: "12.x"
+          node: "16.x"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Use Node.js v16 for CI jobs.