### PR TITLE
fix: upgrade esmock v1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "eslint-plugin-jsdoc": "^37.0.3",
         "eslint-plugin-node": "^11.1.0",
         "eslint-release": "^3.2.0",
-        "esmock": "^1.3.3",
+        "esmock": "^1.7.0",
         "espree": "^9.0.0",
         "fs-teardown": "^0.3.0",
         "lint-staged": "^12.1.2",


### PR DESCRIPTION
it fixes bad mock when there is whitespaces in the file path.