### PR TITLE
fix: cannot find installed eslint

### DIFF
--- a/lib/init/config-file.js
+++ b/lib/init/config-file.js
@@ -16,7 +16,6 @@ import { pathToFileURL } from "url";
 import { createRequire } from "module";
 
 const debug = debugEsm("eslint:config-file");
-const require = createRequire(path.join(process.cwd(), "./__placeholder__"));
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -40,6 +39,7 @@ function sortByKey(a, b) {
  * @returns {Promise<*>} the exported module
  */
 async function importLocalPackage(pkgName) {
+    const require = createRequire(path.join(process.cwd(), "./__placeholder__"));
     const pkgPath = require.resolve(pkgName);
 
     return await import(pathToFileURL(pkgPath)); // eslint-disable-line node/no-unsupported-features/es-syntax


### PR DESCRIPTION
the issue is require was created before eslint was installed. just moving
it to the function importLocalPackage()

fixes #12