### PR TITLE
fix: Wrong info about globally-installed copy of ESLint

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -51,8 +51,6 @@ async function writeFile(config, format) {
         }
     }
 
-    const installedESLint = config.installedESLint;
-
     delete config.installedESLint;
 
     await ConfigFile.write(config, `./.eslintrc${extname}`);


### PR DESCRIPTION
fixes #17 