### PR TITLE
chore: upgrade esmock

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "eslint-plugin-jsdoc": "^37.0.3",
         "eslint-plugin-node": "^11.1.0",
         "eslint-release": "^3.2.0",
-        "esmock": "^1.7.0",
+        "esmock": "^1.7.5",
         "espree": "^9.0.0",
         "fs-teardown": "^0.3.0",
         "lint-staged": "^12.1.2",


### PR DESCRIPTION
it fixes a node.js v17.8 compat issue
refs: https://github.com/iambumblehead/esmock/releases/tag/v1.7.5