### PR TITLE
fix: Vue parse error and support Vue 3

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -173,7 +173,12 @@ function processAnswers(answers) {
         config.extends.push("plugin:react/recommended");
     } else if (answers.framework === "vue") {
         config.plugins = ["vue"];
-        config.extends.push("plugin:vue/essential");
+
+        if (answers.vueVersion === "vue3") {
+            config.extends.push("plugin:vue/vue3-essential");
+        } else {
+            config.extends.push("plugin:vue/essential");
+        }
     }
 
     if (answers.typescript) {
@@ -203,7 +208,17 @@ function processAnswers(answers) {
         }
     }
     if (answers.typescript && config.extends.includes("eslint:recommended")) {
-        config.extends.push("plugin:@typescript-eslint/recommended");
+        if (answers.framework === "vue") {
+            const vueConfigIndex = config.extends.findIndex(c => c.startsWith("plugin:vue"));
+
+            if (vueConfigIndex !== -1) {
+                config.extends.splice(
+                    vueConfigIndex, 0, "plugin:@typescript-eslint/recommended"
+                );
+            }
+        } else {
+            config.extends.push("plugin:@typescript-eslint/recommended");
+        }
     }
 
     // normalize extends
@@ -384,6 +399,19 @@ function promptUser() {
                 { message: "Vue.js", name: "vue" },
                 { message: "None of these", name: "none" }
             ]
+        },
+        {
+            type: "select",
+            name: "vueVersion",
+            message: "Which Vue version does your project use?",
+            initial: 0,
+            choices: [
+                { message: "Vue 3", name: "vue3" },
+                { message: "Vue 2", name: "vue2" }
+            ],
+            skip() {
+                return this.state.answers.framework !== "vue";
+            }
         },
         {
             type: "toggle",

--- a/tests/init/config-initializer.js
+++ b/tests/init/config-initializer.js
@@ -186,11 +186,22 @@ describe("configInitializer", () => {
 
             it("should enable vue plugin", () => {
                 answers.framework = "vue";
+                answers.vueVersion = "vue2";
                 const config = init.processAnswers(answers);
 
                 assert.strictEqual(config.parserOptions.ecmaVersion, "latest");
                 assert.deepStrictEqual(config.plugins, ["vue"]);
                 assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/essential"]);
+            });
+
+            it("should enable vue 3 plugin", () => {
+                answers.framework = "vue";
+                answers.vueVersion = "vue3";
+                const config = init.processAnswers(answers);
+
+                assert.strictEqual(config.parserOptions.ecmaVersion, "latest");
+                assert.deepStrictEqual(config.plugins, ["vue"]);
+                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/vue3-essential"]);
             });
 
             it("should enable typescript parser and plugin", () => {
@@ -204,10 +215,22 @@ describe("configInitializer", () => {
 
             it("should enable typescript parser and plugin with vue", () => {
                 answers.framework = "vue";
+                answers.vueVersion = "vue2";
                 answers.typescript = true;
                 const config = init.processAnswers(answers);
 
-                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/essential", "plugin:@typescript-eslint/recommended"]);
+                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:vue/essential"]);
+                assert.strictEqual(config.parserOptions.parser, "@typescript-eslint/parser");
+                assert.deepStrictEqual(config.plugins, ["vue", "@typescript-eslint"]);
+            });
+
+            it("should enable typescript parser and plugin with vue 3", () => {
+                answers.framework = "vue";
+                answers.vueVersion = "vue3";
+                answers.typescript = true;
+                const config = init.processAnswers(answers);
+
+                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:vue/vue3-essential"]);
                 assert.strictEqual(config.parserOptions.parser, "@typescript-eslint/parser");
                 assert.deepStrictEqual(config.plugins, ["vue", "@typescript-eslint"]);
             });


### PR DESCRIPTION
Currently init vue config will cause parsing error.

![image](https://user-images.githubusercontent.com/35442047/168304898-e46e1ed1-7fe7-425a-ac2f-baaa0dfea45c.png)

This is because `plugin:@typescript-eslint` override the `parser` config, so `plugin:vue` should put in the last position.

```diff
"extends": [
      "eslint:recommended",
-      "plugin:vue/essential",
-      "plugin:@typescript-eslint/recommended",
+      "plugin:@typescript-eslint/recommended",
+      "plugin:vue/essential",
 ],
```

Also, according to [vue eslint doc](https://eslint.vuejs.org/user-guide/#usage), vue 3 should extend `plugin:vue3-*` prefix config.

@aladdin-add 