### PR TITLE
fix: use @typescript-eslint/recommended & support vue3

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -143,10 +143,11 @@ function getModulesList(config, installESLint) {
  */
 function processAnswers(answers) {
     const config = {
-        rules: {},
         env: {},
         parserOptions: {},
-        extends: []
+        extends: [],
+        plugins: [],
+        rules: {}
     };
 
     config.parserOptions.ecmaVersion = "latest";
@@ -165,13 +166,16 @@ function processAnswers(answers) {
     });
 
     if (answers.typescript) {
+        config.plugins.push("@typescript-eslint");
         config.extends.push("plugin:@typescript-eslint/recommended");
     }
 
     // add in library information
     if (answers.framework === "react") {
+        config.plugins.push("react");
         config.extends.push("plugin:react/recommended");
     } else if (answers.framework === "vue") {
+        config.plugins.push("vue");
         config.extends.push("plugin:vue/vue3-recommended");
         if (answers.typescript) {
             config.parserOptions.parser = "@typescript-eslint/parser";
@@ -191,7 +195,10 @@ function processAnswers(answers) {
         }
     }
 
-    // normalize extends
+    // normalize extends/plugins
+    if (config.plugins.length === 0) {
+        delete config.plugins;
+    }
     if (config.extends.length === 0) {
         delete config.extends;
     } else if (config.extends.length === 1) {

--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -164,29 +164,17 @@ function processAnswers(answers) {
         config.env[env] = true;
     });
 
-    // add in library information
-    if (answers.framework === "react") {
-        config.parserOptions.ecmaFeatures = {
-            jsx: true
-        };
-        config.plugins = ["react"];
-        config.extends.push("plugin:react/recommended");
-    } else if (answers.framework === "vue") {
-        config.plugins = ["vue"];
-        config.extends.push("plugin:vue/essential");
+    if (answers.typescript) {
+        config.extends.push("plugin:@typescript-eslint/recommended");
     }
 
-    if (answers.typescript) {
-        if (answers.framework === "vue") {
+    // add in library information
+    if (answers.framework === "react") {
+        config.extends.push("plugin:react/recommended");
+    } else if (answers.framework === "vue") {
+        config.extends.push("plugin:vue/vue3-recommended");
+        if (answers.typescript) {
             config.parserOptions.parser = "@typescript-eslint/parser";
-        } else {
-            config.parser = "@typescript-eslint/parser";
-        }
-
-        if (Array.isArray(config.plugins)) {
-            config.plugins.push("@typescript-eslint");
-        } else {
-            config.plugins = ["@typescript-eslint"];
         }
     }
 
@@ -201,9 +189,6 @@ function processAnswers(answers) {
             config.rules["linebreak-style"] = ["error", answers.linebreak];
             config.rules.semi = ["error", answers.semi ? "always" : "never"];
         }
-    }
-    if (answers.typescript && config.extends.includes("eslint:recommended")) {
-        config.extends.push("plugin:@typescript-eslint/recommended");
     }
 
     // normalize extends

--- a/tests/init/config-initializer.js
+++ b/tests/init/config-initializer.js
@@ -180,6 +180,7 @@ describe("configInitializer", () => {
                 const config = init.processAnswers(answers);
 
                 assert.strictEqual(config.parserOptions.ecmaVersion, "latest");
+                assert.deepStrictEqual(config.plugins, ["react"]);
                 assert.include(config.extends, "plugin:react/recommended");
             });
 
@@ -188,6 +189,7 @@ describe("configInitializer", () => {
                 const config = init.processAnswers(answers);
 
                 assert.strictEqual(config.parserOptions.ecmaVersion, "latest");
+                assert.deepStrictEqual(config.plugins, ["vue"]);
                 assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/vue3-recommended"]);
             });
 
@@ -195,6 +197,7 @@ describe("configInitializer", () => {
                 answers.typescript = true;
                 const config = init.processAnswers(answers);
 
+                assert.deepStrictEqual(config.plugins, ["@typescript-eslint"]);
                 assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:@typescript-eslint/recommended"]);
             });
 
@@ -203,6 +206,7 @@ describe("configInitializer", () => {
                 answers.typescript = true;
                 const config = init.processAnswers(answers);
 
+                assert.deepStrictEqual(config.plugins, ["@typescript-eslint", "vue"]);
                 assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:vue/vue3-recommended"]);
             });
 

--- a/tests/init/config-initializer.js
+++ b/tests/init/config-initializer.js
@@ -179,9 +179,8 @@ describe("configInitializer", () => {
                 answers.framework = "react";
                 const config = init.processAnswers(answers);
 
-                assert.strictEqual(config.parserOptions.ecmaFeatures.jsx, true);
                 assert.strictEqual(config.parserOptions.ecmaVersion, "latest");
-                assert.deepStrictEqual(config.plugins, ["react"]);
+                assert.include(config.extends, "plugin:react/recommended");
             });
 
             it("should enable vue plugin", () => {
@@ -189,16 +188,13 @@ describe("configInitializer", () => {
                 const config = init.processAnswers(answers);
 
                 assert.strictEqual(config.parserOptions.ecmaVersion, "latest");
-                assert.deepStrictEqual(config.plugins, ["vue"]);
-                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/essential"]);
+                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/vue3-recommended"]);
             });
 
             it("should enable typescript parser and plugin", () => {
                 answers.typescript = true;
                 const config = init.processAnswers(answers);
 
-                assert.strictEqual(config.parser, "@typescript-eslint/parser");
-                assert.deepStrictEqual(config.plugins, ["@typescript-eslint"]);
                 assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:@typescript-eslint/recommended"]);
             });
 
@@ -207,9 +203,7 @@ describe("configInitializer", () => {
                 answers.typescript = true;
                 const config = init.processAnswers(answers);
 
-                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/essential", "plugin:@typescript-eslint/recommended"]);
-                assert.strictEqual(config.parserOptions.parser, "@typescript-eslint/parser");
-                assert.deepStrictEqual(config.plugins, ["vue", "@typescript-eslint"]);
+                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:vue/vue3-recommended"]);
             });
 
             it("should extend eslint:recommended", () => {


### PR DESCRIPTION
1. always use `"plugin:@typescript-eslint/recommended"` for ts projects (fixes #32 )
2. update to use vue3/recommended(latest)

react + typescript:
```js
module.exports = {
    "env": {
        "browser": true,
        "es2021": true
    },
    "extends": [
        "eslint:recommended",
        "plugin:@typescript-eslint/recommended",
        "plugin:react/recommended"
    ],
    "parserOptions": {
        "ecmaVersion": "latest",
        "sourceType": "module"
    },
    "plugins": [
        "@typescript-eslint",
        "react"
    ],
    "rules": {
    }
}


```

vue + typescript:
```js
module.exports = {
    "env": {
        "browser": true,
        "es2021": true
    },
    "extends": [
        "eslint:recommended",
        "plugin:@typescript-eslint/recommended",
        "plugin:vue/vue3-recommended"
    ],
    "parserOptions": {
        "ecmaVersion": "latest",
        "parser": "@typescript-eslint/parser",
        "sourceType": "module"
    },
    "plugins": [
        "@typescript-eslint",
        "vue"
    ],
    "rules": {
    }
}


```
