### PR TITLE
ci: add Node v19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
+        node: [19.x, 18.x, 17.x, 16.x, 14.x, 12.x, "12.22.0"]
         include:
         - os: windows-latest
           node: "16.x"

--- a/tests/init/npm-utils.js
+++ b/tests/init/npm-utils.js
@@ -90,7 +90,7 @@ describe("npmUtils", () => {
 
             assert.throws(() => {
                 stubcheckDevDeps(["some-package"]);
-            }, /Unexpected token v/u);
+            }, /JSON/u);
         });
     });
 
@@ -144,7 +144,7 @@ describe("npmUtils", () => {
 
             assert.throws(() => {
                 stubbedcheckDeps(["some-package"]);
-            }, /Unexpected token v/u);
+            }, /JSON/u);
         });
     });
 


### PR DESCRIPTION
Adds Node v19 to `ci.yml`.

https://nodejs.org/en/blog/release/v19.0.0/