### PR TITLE
feat: Proposal to enable the Vue3 plugin to recommended by default

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -180,7 +180,7 @@ function processAnswers(answers) {
         config.extends.push("plugin:react/recommended");
     } else if (answers.framework === "vue") {
         config.plugins = ["vue"];
-        config.extends.push("plugin:vue/vue3-essential");
+        config.extends.push("plugin:vue/vue3-recommended");
     }
 
     // if answers.source == "guide", the ts supports should be in the shared config.

--- a/tests/init/config-initializer.js
+++ b/tests/init/config-initializer.js
@@ -190,7 +190,7 @@ describe("configInitializer", () => {
 
                 assert.strictEqual(config.parserOptions.ecmaVersion, "latest");
                 assert.deepStrictEqual(config.plugins, ["vue"]);
-                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/vue3-essential"]);
+                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/vue3-recommended"]);
             });
 
             it("should enable typescript parser and plugin", () => {
@@ -207,7 +207,7 @@ describe("configInitializer", () => {
                 answers.typescript = true;
                 const config = init.processAnswers(answers);
 
-                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/vue3-essential", "plugin:@typescript-eslint/recommended"]);
+                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/vue3-recommended", "plugin:@typescript-eslint/recommended"]);
                 assert.deepStrictEqual(config.plugins, ["vue", "@typescript-eslint"]);
             });
 
@@ -379,7 +379,7 @@ describe("configInitializer", () => {
             it("should support the standard style guide with Vue.js", () => {
                 const config = {
                     plugins: ["vue"],
-                    extends: ["plugin:vue/vue3-essential", "standard"]
+                    extends: ["plugin:vue/vue3-recommended", "standard"]
                 };
                 const modules = init.getModulesList(config);
 


### PR DESCRIPTION
Hello, ESLint Team!

Thank you for the fantastic CLI tool.

According to the documentation for the official Vue.js ESLint plugin [here](https://eslint.vuejs.org/user-guide/#configuration), the `plugin:vue/vue3-recommended` configuration is used as the default example. Therefore, I believe it would be beneficial to use it as the default configuration.

What do you think? Please let me know your thoughts. Thank you!