### PR TITLE
ci: use LTS node version in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: 'lts/*'
       - name: Install dependencies
         run: npm install
       - name: Lint files
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node }}
     - name: Install dependencies


### PR DESCRIPTION
Use the [Node.js LTS version syntax](https://github.com/actions/setup-node#supported-version-syntax) so we don't have to manually update the node version in the future.