### PR TITLE
chore: set up release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,36 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: node
+          package-name: '@eslint/create-config'
+          pull-request-title-pattern: 'chore: release${component} ${version}'
+      - uses: actions/checkout@v3
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          registry-url: https://registry.npmjs.org
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: ${{ steps.release.outputs.release_created }}
+      - run: 'npx @humanwhocodes/tweet "@eslint/create-config ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+          TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}


### PR DESCRIPTION
Following up on last week's TSC meeting, I'm replicating [`generator-eslint`'s setup](https://github.com/eslint/generator-eslint/blob/main/.github/workflows/release-please.yml) here now that we've [successfully demonstrated](https://github.com/eslint/generator-eslint/actions/runs/4290711710/jobs/7475012200) a release on the lowest-blast-radius repository. `@eslint/create-config` sees more changes so will be a better test of the `release-please` workflow to decide whether we use `release-please` for more projects.

Additional non-code setup:

- [x] Update [organization Actions secrets][1] to give this repository access to `NPM_TOKEN` and the four `TWITTER_*` secrets.
- [x] Update [repository Actions settings][2] to "Allow GitHub Actions to create and approve pull requests".
- [x] Update [npm package settings][3] to allow publishing with 2FA **or** automation or granular access tokens.

[1]: https://github.com/organizations/eslint/settings/secrets/actions
[2]: https://github.com/eslint/create-config/settings/actions
[3]: https://www.npmjs.com/package/@eslint/create-config/access