### PR TITLE
docs: sync `--config` examples with ESLint Getting Started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ If you want to use a specific shareable config that is hosted on npm, you can us
 
 ```bash
 # use `eslint-config-semistandard` shared config
-# npm 6.x
-npm init @eslint/config --config semistandard
 
-# ⚠️ npm 7+, extra double-dash is needed:
+# npm 7+
 npm init @eslint/config -- --config semistandard
 
 # or (`eslint-config` prefix is optional)
 npm init @eslint/config -- --config eslint-config-semistandard
+
+# ⚠️ npm 6.x no extra double-dash:
+npm init @eslint/config --config semistandard
 ```
 
 The `--config` flag also supports passing in arrays:


### PR DESCRIPTION
Updates `--config` examples in the README file to be the same as on https://eslint.org/docs/latest/use/getting-started