### PR TITLE
chore: Also post releases to Mastodon

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,3 +34,8 @@ jobs:
           TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
           TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+      - run: 'npx @humanwhocodes/toot "@eslint/create-config ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+          MASTODON_HOST: ${{ secrets.MASTODON_HOST }}    


### PR DESCRIPTION
This updates the release process to also post on Mastodon.

Copy & paste from https://github.com/eslint/generator-eslint/pull/152