### PR TITLE
chore: include all commits in the changelog

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,18 @@ jobs:
           release-type: node
           package-name: '@eslint/create-config'
           pull-request-title-pattern: 'chore: release${component} ${version}'
+          changelog-types: >
+            [
+              { "type": "feat", "section": "Features", "hidden": false },
+              { "type": "fix", "section": "Bug Fixes", "hidden": false },
+              { "type": "docs", "section": "Documentation", "hidden": false },
+              { "type": "build", "section": "Build Related", "hidden": false },
+              { "type": "chore", "section": "Chores", "hidden": false },
+              { "type": "perf", "section": "Chores", "hidden": false },
+              { "type": "ci", "section": "Chores", "hidden": false },
+              { "type": "refactor", "section": "Chores", "hidden": false },
+              { "type": "test", "section": "Chores", "hidden": false }
+            ]
       - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v3


### PR DESCRIPTION
`release-please` creates a release PR after it notices the default branch contains "releasable units" since the last release. By default, releasable units are commits tagged as `feat`, `fix`, or `deps` (we're not using this one). So, currently, we can release a new version only if there is at least one `feat` or `fix` commit since the last version.

Sometimes, we'd like to release a new version even if there are no `feat` or `fix` commits. In particular, in some cases when there are commits tagged with:

* `perf` - the new version will have better performance
* `chore` - we use `chore` for dependency upgrades too
* `docs` - to update README on npm

Also, only releasable units appear in changelogs, while we used to list all commits.

In the last TSC meeting, we decided to configure `release-please` so that all commits will trigger the creation of a release PR. 
Since we control if and when the PR will be merged, there is no harm in that.

Per https://github.com/googleapis/release-please/issues/1312, anything that is visible in the changelog is considered releasable, so configuring `release-please` to include all of our commit tags in changelogs should do the work.

I configured the [`changelog-types`](https://github.com/google-github-actions/release-please-action#overriding-the-changelog-sections)  option to include all 9 tags we're using. Section names are the same as in [`eslint-release`](https://github.com/eslint/eslint-release/blob/e4cc0d1901abd6d24f01ddca6aac9c4050886ee7/lib/release-ops.js#L403-L412). I tested this in a repo and all seems to be working fine, except that I didn't figure out how to reorder the sections to match eslint-release's order, which is: Features - Bug Fixes - Documentation - Build Related - Chores. Features and Bug Fixes are always first, but after that, it seems that release-please orders the remaining sections alphabetically, so we'll have: Features - Bug Fixes - Build Related - Chores - Documentation.