### PR TITLE
chore: Update tweet message

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,14 +39,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         if: ${{ steps.release.outputs.release_created }}
-      - run: 'npx @humanwhocodes/tweet "@eslint/create-config ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
+      - run: 'npx @humanwhocodes/tweet "eslint/create-config ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
         if: ${{ steps.release.outputs.release_created }}
         env:
           TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
           TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
           TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-      - run: 'npx @humanwhocodes/toot "@eslint/create-config ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
+      - run: 'npx @humanwhocodes/toot "eslint/create-config ${{ steps.release.outputs.tag_name }} has been released: ${{ steps.release.outputs.html_url }}"'
         if: ${{ steps.release.outputs.release_created }}
         env:
           MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}


### PR DESCRIPTION
Remove the `@` sign from the start of tweets/toots to ensure it's not marked as a mention.