### PR TITLE
fix: generated vue-ts config

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -222,7 +222,7 @@ function processAnswers(answers) {
 
     // add in library information
     // The configuration of the framework plugins should be placed at the end of extends.
-    if (answers.framework === "react") {
+    if (answers.framework === "react" && answers.styleguide !== "airbnb") {
         config.plugins.push("react");
         config.extends.push("plugin:react/recommended");
     } else if (answers.framework === "vue") {

--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -156,6 +156,7 @@ function processAnswers(answers) {
         env: {},
         parserOptions: {},
         extends: [],
+        plugins: [],
         overrides: []
     };
 
@@ -174,18 +175,16 @@ function processAnswers(answers) {
         config.env[env] = true;
     });
 
-    // add in library information
-    if (answers.framework === "react") {
-        config.plugins = ["react"];
-        config.extends.push("plugin:react/recommended");
-    } else if (answers.framework === "vue") {
-        config.plugins = ["vue"];
-        config.extends.push("plugin:vue/vue3-essential");
-    }
-
     // if answers.source == "guide", the ts supports should be in the shared config.
     if (answers.typescript && answers.source !== "guide") {
-        config.parser = "@typescript-eslint/parser";
+
+        // .vue files should be parsed by vue-eslint-parser.
+        // https://eslint.vuejs.org/user-guide/#how-to-use-a-custom-parser
+        if (answers.framework === "vue") {
+            config.parserOptions.parser = "@typescript-eslint/parser";
+        } else {
+            config.parser = "@typescript-eslint/parser";
+        }
 
         if (Array.isArray(config.plugins)) {
             config.plugins.push("@typescript-eslint");
@@ -209,7 +208,6 @@ function processAnswers(answers) {
         }
     }
 
-
     // setup rules based on problems/style enforcement preferences
     if (answers.purpose === "problems") {
         config.extends.unshift("eslint:recommended");
@@ -226,11 +224,27 @@ function processAnswers(answers) {
         config.extends.push("plugin:@typescript-eslint/recommended");
     }
 
+    // add in library information
+    // The configuration of the framework plugins should be placed at the end of extends.
+    if (answers.framework === "react") {
+        config.plugins.push("react");
+        config.extends.push("plugin:react/recommended");
+    } else if (answers.framework === "vue") {
+        config.plugins.push("vue");
+        config.extends.push("plugin:vue/vue3-essential");
+    }
+
     // normalize extends
     if (config.extends.length === 0) {
         delete config.extends;
     } else if (config.extends.length === 1) {
         config.extends = config.extends[0];
+    }
+    if (config.overrides.length === 0) {
+        delete config.overrides;
+    }
+    if (config.plugins.length === 0) {
+        delete config.plugins;
     }
 
     ConfigOps.normalizeToStrings(config);

--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -186,11 +186,7 @@ function processAnswers(answers) {
             config.parser = "@typescript-eslint/parser";
         }
 
-        if (Array.isArray(config.plugins)) {
-            config.plugins.push("@typescript-eslint");
-        } else {
-            config.plugins = ["@typescript-eslint"];
-        }
+        config.plugins.push("@typescript-eslint");
     }
 
     // set config.extends based the selected guide

--- a/tests/init/config-initializer.js
+++ b/tests/init/config-initializer.js
@@ -207,8 +207,9 @@ describe("configInitializer", () => {
                 answers.typescript = true;
                 const config = init.processAnswers(answers);
 
-                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:vue/vue3-essential", "plugin:@typescript-eslint/recommended"]);
-                assert.deepStrictEqual(config.plugins, ["vue", "@typescript-eslint"]);
+                assert.include(config.parserOptions, { parser: "@typescript-eslint/parser" });
+                assert.deepStrictEqual(config.extends, ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:vue/vue3-essential"]);
+                assert.deepStrictEqual(config.plugins, ["@typescript-eslint", "vue"]);
             });
 
             it("should extend eslint:recommended", () => {


### PR DESCRIPTION
fixes https://github.com/eslint/eslint/discussions/17221

it's a bug when choosing vue+ts. to repro:
```bash
➜  $ npm init @eslint/config                                           
Need to install the following packages:
  @eslint/create-config@0.4.3
Ok to proceed? (y) y
✔ How would you like to use ESLint? · problems
✔ What type of modules does your project use? · esm
✔ Which framework does your project use? · vue
✔ Does your project use TypeScript? · No / Yes
✔ Where does your code run? · browser
✔ What format do you want your config file to be in? · JavaScript
The config that you've selected requires the following dependencies:

eslint-plugin-vue@latest @typescript-eslint/eslint-plugin@latest @typescript-eslint/parser@latest
✔ Would you like to install them now? · No / Yes
✔ Which package manager do you want to use? · npm
```
the generated config (`.eslintrc.cjs`):
```js
module.exports = {
    "env": {
        "browser": true,
        "es2021": true
    },
    "extends": [
        "eslint:recommended",
        "plugin:vue/vue3-essential",
        "plugin:@typescript-eslint/recommended"
    ],
    "overrides": [
    ],
    "parser": "@typescript-eslint/parser",
    "parserOptions": {
        "ecmaVersion": "latest",
        "sourceType": "module"
    },
    "plugins": [
        "vue",
        "@typescript-eslint"
    ],
    "rules": {
    }
}

```

the cause is `.vue` files should be parsed by `vue-eslint-parser`, not `@typescript-eslint/parser`. Its documentation says that custom parsers should use `parserOption.parser` to config. 
https://eslint.vuejs.org/user-guide/#how-to-use-a-custom-parser


the new generated config:
```js
module.exports = {
    "env": {
        "browser": true,
        "es2021": true
    },
    "extends": [
        "eslint:recommended",
        "plugin:@typescript-eslint/recommended",
        "plugin:vue/vue3-essential"
    ],
    "parserOptions": {
        "ecmaVersion": "latest",
        "parser": "@typescript-eslint/parser",
        "sourceType": "module"
    },
    "plugins": [
        "@typescript-eslint",
        "vue"
    ],
    "rules": {
    }
}
```

