### PR TITLE
Fixing standard-with-typescript style guide

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -219,6 +219,10 @@ function processAnswers(answers) {
                 files: ["*.ts", "*.tsx"],
                 extends: ["xo-typescript"]
             });
+        } else if (answers.styleguide === "standard-with-typescript") {
+            config.parserOptions.project = true;
+            config.parserOptions.tsconfigRootDir = "__dirname";
+            config.extends.push("standard-with-typescript");
         } else {
             config.extends.push(answers.styleguide);
         }

--- a/tests/init/config-initializer.js
+++ b/tests/init/config-initializer.js
@@ -277,6 +277,23 @@ describe("configInitializer", () => {
                 assert.include(modules, "eslint-config-standard@latest");
             });
 
+            it("should support the standard-with-typescript style guide", () => {
+                answers = {
+                    env: [],
+                    purpose: "style",
+                    source: "guide",
+                    moduleType: "esm",
+                    typescript: true,
+                    styleguide: "standard-with-typescript"
+                };
+                const config = init.processAnswers(answers);
+
+                assert.include(config, { extends: "standard-with-typescript" });
+                assert.include(config.parserOptions, {
+                    project: true, tsconfigRootDir: "__dirname"
+                });
+            });
+
             it("should support the xo style guide", () => {
                 const config = { extends: "xo" };
                 const modules = init.getModulesList(config);


### PR DESCRIPTION
Addressing issue: https://github.com/eslint/create-config/issues/71