### PR TITLE
chore: run tests on all supported versions of Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "eslint": "^8.48.0",
         "eslint-config-eslint": "^9.0.0",
         "eslint-release": "^3.2.0",
-        "esmock": "^2.2.3",
+        "esmock": "~2.3.8",
         "espree": "^9.0.0",
         "globals": "^13.21.0",
         "lint-staged": "^12.1.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     },
     "scripts": {
         "lint": "eslint . --report-unused-disable-directives",
+        "postinstall": "node tests/patch-esmock.js",
         "release:generate:latest": "eslint-generate-release",
         "release:generate:alpha": "eslint-generate-prerelease alpha",
         "release:generate:beta": "eslint-generate-prerelease beta",
@@ -58,7 +59,8 @@
         "eslint": "^8.48.0",
         "eslint-config-eslint": "^9.0.0",
         "eslint-release": "^3.2.0",
-        "esmock": "~2.3.8",
+        "esmock": "^2.5.8",
+        "esmock_legacy": "npm:esmock@~2.3.8",
         "espree": "^9.0.0",
         "globals": "^13.21.0",
         "lint-staged": "^12.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     },
     "scripts": {
         "lint": "eslint . --report-unused-disable-directives",
-        "postinstall": "node tests/patch-esmock.js",
+        "prepare": "node tests/patch-esmock.js",
         "release:generate:latest": "eslint-generate-release",
         "release:generate:alpha": "eslint-generate-prerelease alpha",
         "release:generate:beta": "eslint-generate-prerelease beta",

--- a/tests/patch-esmock.js
+++ b/tests/patch-esmock.js
@@ -11,6 +11,11 @@ import { promises as fs } from "fs";
 // 111 is the ABI version number of Node.js 19: https://nodejs.org/en/download/releases
 if (process.versions.modules < 111) {
     (async () => {
+        try {
+            await fs.access("node_modules/esmock_legacy");
+        } catch {
+            return;
+        }
         await fs.rmdir("node_modules/esmock", { recursive: true });
         await fs.rename("node_modules/esmock_legacy", "node_modules/esmock");
     })();

--- a/tests/patch-esmock.js
+++ b/tests/patch-esmock.js
@@ -5,8 +5,10 @@
 
 import { promises as fs } from "fs";
 
-// esmock < 2.4 supports only Node.js < 19. esmock >= 2.4 supports only Node.js >= 18.6.
+// * esmock < 2.4 works only on Node.js < 19.
+// * esmock >= 2.4 works only on Node.js >= 18.6.
 // If we are running Node.js < 19, replace the esmock dependency with the legacy release.
+// 111 is the ABI version number of Node.js 19: https://nodejs.org/en/download/releases
 if (process.versions.modules < 111) {
     (async () => {
         await fs.rmdir("node_modules/esmock", { recursive: true });

--- a/tests/patch-esmock.js
+++ b/tests/patch-esmock.js
@@ -1,0 +1,15 @@
+/**
+ * @fileoverview Run by npm to replace esmock with a legacy release on older versions of Node.js.
+ * @author Francesco Trotta
+ */
+
+import { promises as fs } from "fs";
+
+// esmock < 2.4 supports only Node.js < 19. esmock >= 2.4 supports only Node.js >= 18.6.
+// If we are running Node.js < 19, replace the esmock dependency with the legacy release.
+if (process.versions.modules < 111) {
+    (async () => {
+        await fs.rmdir("node_modules/esmock", { recursive: true });
+        await fs.rename("node_modules/esmock_legacy", "node_modules/esmock");
+    })();
+}


### PR DESCRIPTION
This PR fixes the unit tests on previous versions of Node.js (< 18). These tests are currently no longer working because of a breaking change in a dependency. See for example https://github.com/eslint/create-config/actions/runs/6609176505.

Unit tests in this package use esmock as a dev dependency.

- esmock < 2.4 works only on Node.js < 19.
- esmock >= 2.4 works only on Node.js >= 18.6.

(These is not officially specified information, I determined it by testing)

In order to run unit tests on all versions of Node.js that we need to support, I have created a postinstall script that checks the version of Node.js and replaces the esmock folder in node_modules with a legacy release on Node.js < 19.
