### PR TITLE
fix: add `log.warn`

### DIFF
--- a/lib/utils/logging.js
+++ b/lib/utils/logging.js
@@ -16,6 +16,15 @@ export function info(...args) {
 }
 
 /**
+ * Cover for console.warn
+ * @param {...any} args The elements to log.
+ * @returns {void}
+ */
+export function warn(...args) {
+    console.warn(...args);
+}
+
+/**
  * Cover for console.error
  * @param {...any} args The elements to log.
  * @returns {void}


### PR DESCRIPTION
`log.warn` export was missing

https://github.com/eslint/create-config/blob/54ac1f2bb213e60c9b387c01cc674cb03b1aafed/lib/config-generator.js#L275

```
The config that you've selected requires the following dependencies:

eslint, globals, @eslint/js
√ Would you like to install them now? · No / Yes
Successfully created C:\projects\create-config\eslint.config.js file.
file:///C:/projects/create-config/lib/config-generator.js:275
            log.warn("You will need to install the dependencies yourself.");
                ^

TypeError: log.warn is not a function
    at ConfigGenerator.output (file:///C:/projects/create-config/lib/config-generator.js:275:17)
    at async file:///C:/projects/create-config/bin/create-config.js:28:5
```
