### PR TITLE
chore: run `npm install` before npm publish

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,12 +29,14 @@ jobs:
               { "type": "refactor", "section": "Chores", "hidden": false },
               { "type": "test", "section": "Chores", "hidden": false }
             ]
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm install
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish --provenance
         env:
@@ -51,4 +53,4 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         env:
           MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
-          MASTODON_HOST: ${{ secrets.MASTODON_HOST }}    
+          MASTODON_HOST: ${{ secrets.MASTODON_HOST }}


### PR DESCRIPTION
another way is to remove `node-options=--loader=esmock` in `.npmrc`, and adding the env in npm scripts instead.

fixes https://github.com/eslint/create-config/issues/86