### PR TITLE
fix: not install multi tseslint versions

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -144,6 +144,13 @@ export class ConfigGenerator {
             this.answers.framework = "none";
         }
 
+        // tseslint should have been a dependency in the shared configs
+        // avoid install tseslint - it may install multi tseslint versions
+        // see https://github.com/eslint/create-config/issues/97
+        if (this.answers.styleguide && this.answers.language === "typescript") {
+            this.answers.language = "javascript";
+        }
+
         let importContent = "";
         const helperContent = `import path from "path";
 import { fileURLToPath } from "url";

--- a/tests/__snapshots__/style-esm-none-xo-typescript
+++ b/tests/__snapshots__/style-esm-none-xo-typescript
@@ -1,6 +1,5 @@
 {
   "configContent": "import globals from "globals";
-import tseslint from "typescript-eslint";
 
 import path from "path";
 import { fileURLToPath } from "url";
@@ -15,7 +14,6 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: plug
 export default [
   {languageOptions: { globals: globals.browser }},
   ...compat.extends("xo-typescript"),
-  ...tseslint.configs.recommended,
 ];",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
@@ -26,7 +24,6 @@ export default [
     "@typescript-eslint/parser@>=7.0.2",
     "eslint@>=8.56.0",
     "typescript@>=5.0.0",
-    "typescript-eslint",
     "@eslint/eslintrc",
     "@eslint/js",
   ],


### PR DESCRIPTION
The ts style guide typically depend on tseslint, so there's no need to install it separately. Doing so might result in multiple versions being installed, leading to errors.

fixes #97, #98