### PR TITLE
docs: use @eslint/create-config latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ You can use npm/npx(shipped with Node.js).
 
 ```bash
 # use npm
-npm init @eslint/config
+npm init @eslint/config@latest
 ```
 
 ```bash
 # use npx
-npx @eslint/create-config
+npx @eslint/create-config@latest
 ```
 
 If you want to use a specific shareable config that is hosted on npm, you can use the `--config` option and specify the package name:
 
 ```bash
 # use `eslint-config-standard` shared config
-npm init @eslint/config -- --config eslint-config-standard
+npm init @eslint/config@latest -- --config eslint-config-standard
 ```
 
 To use an eslintrc-style (legacy) shared config:


### PR DESCRIPTION
We've received a few reports generated configs seem to be eslintrc format, so I've updated the documentation to use the latest version.

refs: https://github.com/eslint/eslint/issues/18369, https://github.com/eslint/eslint/discussions/18361,