### PR TITLE
ci: run tests in Node.js 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
       - name: Install dependencies
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [21.x, 20.x, 18.x, "18.18.0"]
+        node: [22.x, 21.x, 20.x, 18.x, "18.18.0"]
         include:
         - os: windows-latest
           node: "lts/*"


### PR DESCRIPTION
Updates CI workflow to run tests in Node.js 22 as well. Also bumps `actions/checkout` and `actions/setup-node` to v4 for the Lint job.