### PR TITLE
ci: reduce list of releasable tags to `feat`, `fix` and `perf`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,13 +21,7 @@ jobs:
             [
               { "type": "feat", "section": "Features", "hidden": false },
               { "type": "fix", "section": "Bug Fixes", "hidden": false },
-              { "type": "docs", "section": "Documentation", "hidden": false },
-              { "type": "build", "section": "Build Related", "hidden": false },
-              { "type": "chore", "section": "Chores", "hidden": false },
-              { "type": "perf", "section": "Chores", "hidden": false },
-              { "type": "ci", "section": "Chores", "hidden": false },
-              { "type": "refactor", "section": "Chores", "hidden": false },
-              { "type": "test", "section": "Chores", "hidden": false }
+              { "type": "perf", "section": "Performance Improvements", "hidden": false }
             ]
       - uses: actions/checkout@v4
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Per https://github.com/eslint/eslint/issues/18455, only commits tagged as `feat`, `fix`, or `perf` should trigger a release.

This PR removes all other tags from `changelog-types` in the release-please configuration.

This means that release-please will no longer consider commits tagged as `docs`, `build`, `chore`, `ci`, `refactor`, or `test` as   "releasable units" and will thus no longer create a release PR for those commits. Note that this also means that those commits won't be included in the changelog.

If we merge this before https://github.com/eslint/create-config/pull/112, I believe it will remove "switch to eslint v9, eslint-config-eslint v10" from the changelog there, which is okay.