### PR TITLE
test: replace esmock with sinon

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 package-lock=false
-node-options=--loader=esmock

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
         "eslint": "^9.1.1",
         "eslint-config-eslint": "^10.0.0",
         "eslint-release": "^3.2.0",
-        "esmock": "^2.5.8",
         "lint-staged": "^12.1.2",
         "memfs": "^3.4.0",
         "sinon": "^12.0.1",

--- a/tests/utils/npm-utils.spec.js
+++ b/tests/utils/npm-utils.spec.js
@@ -18,6 +18,7 @@ import {
 } from "../../lib/utils/npm-utils.js";
 import { defineInMemoryFs } from "../_utils/in-memory-fs.js";
 import { assert, describe, afterEach, it } from "vitest";
+import fs from "fs";
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -30,7 +31,6 @@ import { assert, describe, afterEach, it } from "vitest";
  */
 async function useInMemoryFileSystem(files) {
     const inMemoryFs = defineInMemoryFs({ files });
-    const { default: fs } = await import("fs");
 
     sinon.replace(fs, "readFileSync", inMemoryFs.readFileSync);
     sinon.replace(fs, "existsSync", inMemoryFs.existsSync);


### PR DESCRIPTION
Fix tests in Node.js 22.2.0 by using sinon to mock dependencies instead of esmock.

Fixes #116