### PR TITLE
fix: enable linting `.jsx` files when React is selected

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -181,6 +181,7 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: plug
         }
 
         if (this.answers.framework === "react") {
+            exportContent += "  { files: [\"**/*.jsx\"], languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },\n";
             if (this.answers.eslintVersion === "9.x") {
                 this.result.devDependencies.push("eslint-plugin-react", "@eslint/compat");
                 if (!this.result.installFlags.includes("--force")) {

--- a/tests/__snapshots__/problems-esm-react-eslint8.x-javascript
+++ b/tests/__snapshots__/problems-esm-react-eslint8.x-javascript
@@ -7,6 +7,7 @@ import pluginReactConfig from "eslint-plugin-react/configs/recommended.js";
 export default [
   {languageOptions: { globals: globals.browser }},
   pluginJs.configs.recommended,
+  { files: ["**/*.jsx"], languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },
   pluginReactConfig,
 ];",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-esm-react-eslint8.x-typescript
+++ b/tests/__snapshots__/problems-esm-react-eslint8.x-typescript
@@ -9,6 +9,7 @@ export default [
   {languageOptions: { globals: globals.browser }},
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
+  { files: ["**/*.jsx"], languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },
   pluginReactConfig,
 ];",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-esm-react-eslint9.x-javascript
+++ b/tests/__snapshots__/problems-esm-react-eslint9.x-javascript
@@ -8,6 +8,7 @@ import { fixupConfigRules } from "@eslint/compat";
 export default [
   {languageOptions: { globals: globals.browser }},
   pluginJs.configs.recommended,
+  { files: ["**/*.jsx"], languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },
   ...fixupConfigRules(pluginReactConfig),
 ];",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-esm-react-eslint9.x-typescript
+++ b/tests/__snapshots__/problems-esm-react-eslint9.x-typescript
@@ -10,6 +10,7 @@ export default [
   {languageOptions: { globals: globals.browser }},
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
+  { files: ["**/*.jsx"], languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },
   ...fixupConfigRules(pluginReactConfig),
 ];",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-esm-react-eslint8.x-javascript
+++ b/tests/__snapshots__/syntax-esm-react-eslint8.x-javascript
@@ -5,6 +5,7 @@ import pluginReactConfig from "eslint-plugin-react/configs/recommended.js";
 
 export default [
   {languageOptions: { globals: globals.browser }},
+  { files: ["**/*.jsx"], languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },
   pluginReactConfig,
 ];",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-esm-react-eslint8.x-typescript
+++ b/tests/__snapshots__/syntax-esm-react-eslint8.x-typescript
@@ -7,6 +7,7 @@ import pluginReactConfig from "eslint-plugin-react/configs/recommended.js";
 export default [
   {languageOptions: { globals: globals.browser }},
   ...tseslint.configs.recommended,
+  { files: ["**/*.jsx"], languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },
   pluginReactConfig,
 ];",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-esm-react-eslint9.x-javascript
+++ b/tests/__snapshots__/syntax-esm-react-eslint9.x-javascript
@@ -6,6 +6,7 @@ import { fixupConfigRules } from "@eslint/compat";
 
 export default [
   {languageOptions: { globals: globals.browser }},
+  { files: ["**/*.jsx"], languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },
   ...fixupConfigRules(pluginReactConfig),
 ];",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-esm-react-eslint9.x-typescript
+++ b/tests/__snapshots__/syntax-esm-react-eslint9.x-typescript
@@ -8,6 +8,7 @@ import { fixupConfigRules } from "@eslint/compat";
 export default [
   {languageOptions: { globals: globals.browser }},
   ...tseslint.configs.recommended,
+  { files: ["**/*.jsx"], languageOptions: { parserOptions: { ecmaFeatures: { jsx: true } } } },
   ...fixupConfigRules(pluginReactConfig),
 ];",
   "configFilename": "eslint.config.js",


### PR DESCRIPTION
I saw this problem mentioned several times in issues/discussions:

```
$ npx @eslint/create-config
√ How would you like to use ESLint? · problems    
√ What type of modules does your project use? · esm
√ Which framework does your project use? · react
√ The React plugin doesn't officially support ESLint v9 yet. What would you like to do? · 9.x
√ Does your project use TypeScript? · javascript
√ Where does your code run? · browser
The config that you've selected requires the following dependencies:

eslint@9.x, globals, @eslint/js, eslint-plugin-react, @eslint/compat
√ Would you like to install them now? · No / Yes
√ Which package manager do you want to use? · npm
☕️Installing...

...

Successfully created C:\projects\tmp\tmp\eslint.config.mjs file.

$ npx eslint a.jsx

C:\projects\tmp\tmp\a.jsx
  0:0  warning  File ignored because of a matching ignore pattern. Use "--no-ignore" to disable file ignore settings or use "--no-warn-ignored" to suppress this warning

✖ 1 problem (0 errors, 1 warning)
```

This PR adds a config for `**/*.jsx` files when React is selected so that they become lintable right away with the created config file.