### PR TITLE
fix: Add custom ts parser for vue projects

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -180,6 +180,11 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: plug
             this.result.devDependencies.push("eslint-plugin-vue");
             importContent += "import pluginVue from \"eslint-plugin-vue\";\n";
             exportContent += "  ...pluginVue.configs[\"flat/essential\"],\n";
+
+            // https://eslint.vuejs.org/user-guide/#how-to-use-a-custom-parser
+            if (this.answers.language === "typescript") {
+                exportContent += "  {files: [\"**/*.vue\"], languageOptions: {parserOptions: {parser: tseslint.parser}}},\n";
+            }
         }
 
         if (this.answers.framework === "react") {

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -12,6 +12,7 @@ export default [
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   ...pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -11,6 +11,7 @@ export default [
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   ...pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -12,6 +12,7 @@ export default [
   pluginJs.configs.recommended,
   ...tseslint.configs.recommended,
   ...pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/syntax-commonjs-vue-typescript
+++ b/tests/__snapshots__/syntax-commonjs-vue-typescript
@@ -10,6 +10,7 @@ export default [
   {languageOptions: { globals: {...globals.browser, ...globals.node} }},
   ...tseslint.configs.recommended,
   ...pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/syntax-esm-vue-typescript
+++ b/tests/__snapshots__/syntax-esm-vue-typescript
@@ -9,6 +9,7 @@ export default [
   {languageOptions: { globals: {...globals.browser, ...globals.node} }},
   ...tseslint.configs.recommended,
   ...pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/syntax-script-vue-typescript
+++ b/tests/__snapshots__/syntax-script-vue-typescript
@@ -10,6 +10,7 @@ export default [
   {languageOptions: { globals: {...globals.browser, ...globals.node} }},
   ...tseslint.configs.recommended,
   ...pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [


### PR DESCRIPTION
This commit modifies the ESLint config generator to add a custom parser for TypeScript files when the language option is set to "typescript". This change is necessary to ensure proper linting of Vue files with TypeScript code.

refs: https://eslint.vuejs.org/user-guide/#how-to-use-a-custom-parser