### PR TITLE
feat: typescript-eslint v8 has supported eslint v9

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -4,7 +4,6 @@
  */
 import process from "node:process";
 import path from "node:path";
-import fs from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import enquirer from "enquirer";
@@ -29,7 +28,7 @@ export class ConfigGenerator {
         this.packageJsonPath = options.packageJsonPath || findPackageJson(this.cwd);
         this.answers = options.answers || {};
         this.result = {
-            devDependencies: ["eslint@9.x"],
+            devDependencies: ["eslint"],
             configFilename: "eslint.config.js",
             configContent: "",
             installFlags: ["-D"]
@@ -157,7 +156,6 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: plug
         if (this.answers.language === "typescript") {
             extensions.push("ts");
             this.result.devDependencies.push("typescript-eslint");
-            this.result.installFlags.push("--force"); // tseslint does not support eslint 9.x yet
             importContent += "import tseslint from \"typescript-eslint\";\n";
             exportContent += "  ...tseslint.configs.recommended,\n";
         }
@@ -265,17 +263,6 @@ export default [\n${exportContent}];`;
         const configPath = path.join(this.cwd, this.result.configFilename);
 
         if (executeInstallation === true) {
-
-            // removing `--force` when:
-            // 1. yarn v2+ -- it does not support it.
-            if (packageManager === "yarn") {
-                const index = this.result.installFlags.indexOf("--force");
-
-                if (index !== -1) {
-                    this.result.installFlags.splice(index, 1);
-                }
-            }
-
             log.info("☕️Installing...");
             installSyncSaveDev(this.result.devDependencies, packageManager, this.result.installFlags);
             await writeFile(configPath, this.result.configContent);
@@ -295,18 +282,6 @@ export default [\n${exportContent}];`;
 
             log.info(`Successfully created ${configPath} file.`);
             log.warn("You will need to install the dependencies yourself.");
-        }
-
-        if (this.result.installFlags.includes("--force")) {
-            let message = "Note that some plugins currently do not support ESLint v9 yet.\nYou may need to use '--force' when installing";
-
-            if (packageManager === "npm") {
-                const pkg = JSON.parse(await fs.readFile(this.packageJsonPath, "utf8"));
-
-                message += `, or add the following to your package.json: \n"overrides": { "eslint": "${pkg.devDependencies.eslint}" } `;
-            }
-
-            log.warn(message);
         }
     }
 }

--- a/tests/__snapshots__/problems-commonjs-none-javascript
+++ b/tests/__snapshots__/problems-commonjs-none-javascript
@@ -10,7 +10,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
   ],

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -13,13 +13,12 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "typescript-eslint",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/problems-commonjs-react-javascript
+++ b/tests/__snapshots__/problems-commonjs-react-javascript
@@ -13,7 +13,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "eslint-plugin-react",

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -15,7 +15,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "typescript-eslint",
@@ -23,6 +23,5 @@ export default [
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/problems-commonjs-vue-javascript
+++ b/tests/__snapshots__/problems-commonjs-vue-javascript
@@ -13,7 +13,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "eslint-plugin-vue",

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -16,7 +16,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "typescript-eslint",
@@ -24,6 +24,5 @@ export default [
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/problems-esm-none-javascript
+++ b/tests/__snapshots__/problems-esm-none-javascript
@@ -9,7 +9,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
   ],

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -12,13 +12,12 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "typescript-eslint",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/problems-esm-react-javascript
+++ b/tests/__snapshots__/problems-esm-react-javascript
@@ -12,7 +12,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "eslint-plugin-react",

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -14,7 +14,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "typescript-eslint",
@@ -22,6 +22,5 @@ export default [
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/problems-esm-vue-javascript
+++ b/tests/__snapshots__/problems-esm-vue-javascript
@@ -12,7 +12,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "eslint-plugin-vue",

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -15,7 +15,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "typescript-eslint",
@@ -23,6 +23,5 @@ export default [
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/problems-script-none-javascript
+++ b/tests/__snapshots__/problems-script-none-javascript
@@ -10,7 +10,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
   ],

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -13,13 +13,12 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "typescript-eslint",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/problems-script-react-javascript
+++ b/tests/__snapshots__/problems-script-react-javascript
@@ -13,7 +13,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "eslint-plugin-react",

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -15,7 +15,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "typescript-eslint",
@@ -23,6 +23,5 @@ export default [
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/problems-script-vue-javascript
+++ b/tests/__snapshots__/problems-script-vue-javascript
@@ -13,7 +13,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "eslint-plugin-vue",

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -16,7 +16,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "@eslint/js",
     "typescript-eslint",
@@ -24,6 +24,5 @@ export default [
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/syntax-commonjs-none-javascript
+++ b/tests/__snapshots__/syntax-commonjs-none-javascript
@@ -8,7 +8,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
   ],
   "installFlags": [

--- a/tests/__snapshots__/syntax-commonjs-none-typescript
+++ b/tests/__snapshots__/syntax-commonjs-none-typescript
@@ -11,12 +11,11 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "typescript-eslint",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/syntax-commonjs-react-javascript
+++ b/tests/__snapshots__/syntax-commonjs-react-javascript
@@ -11,7 +11,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "eslint-plugin-react",
   ],

--- a/tests/__snapshots__/syntax-commonjs-react-typescript
+++ b/tests/__snapshots__/syntax-commonjs-react-typescript
@@ -13,13 +13,12 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "typescript-eslint",
     "eslint-plugin-react",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/syntax-commonjs-vue-javascript
+++ b/tests/__snapshots__/syntax-commonjs-vue-javascript
@@ -11,7 +11,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "eslint-plugin-vue",
   ],

--- a/tests/__snapshots__/syntax-commonjs-vue-typescript
+++ b/tests/__snapshots__/syntax-commonjs-vue-typescript
@@ -14,13 +14,12 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "typescript-eslint",
     "eslint-plugin-vue",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/syntax-esm-none-javascript
+++ b/tests/__snapshots__/syntax-esm-none-javascript
@@ -7,7 +7,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
   ],
   "installFlags": [

--- a/tests/__snapshots__/syntax-esm-none-typescript
+++ b/tests/__snapshots__/syntax-esm-none-typescript
@@ -10,12 +10,11 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "typescript-eslint",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/syntax-esm-react-javascript
+++ b/tests/__snapshots__/syntax-esm-react-javascript
@@ -10,7 +10,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "eslint-plugin-react",
   ],

--- a/tests/__snapshots__/syntax-esm-react-typescript
+++ b/tests/__snapshots__/syntax-esm-react-typescript
@@ -12,13 +12,12 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "typescript-eslint",
     "eslint-plugin-react",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/syntax-esm-vue-javascript
+++ b/tests/__snapshots__/syntax-esm-vue-javascript
@@ -10,7 +10,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "eslint-plugin-vue",
   ],

--- a/tests/__snapshots__/syntax-esm-vue-typescript
+++ b/tests/__snapshots__/syntax-esm-vue-typescript
@@ -13,13 +13,12 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "typescript-eslint",
     "eslint-plugin-vue",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/syntax-script-none-javascript
+++ b/tests/__snapshots__/syntax-script-none-javascript
@@ -8,7 +8,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
   ],
   "installFlags": [

--- a/tests/__snapshots__/syntax-script-none-typescript
+++ b/tests/__snapshots__/syntax-script-none-typescript
@@ -11,12 +11,11 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "typescript-eslint",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/syntax-script-react-javascript
+++ b/tests/__snapshots__/syntax-script-react-javascript
@@ -11,7 +11,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "eslint-plugin-react",
   ],

--- a/tests/__snapshots__/syntax-script-react-typescript
+++ b/tests/__snapshots__/syntax-script-react-typescript
@@ -13,13 +13,12 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "typescript-eslint",
     "eslint-plugin-react",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }

--- a/tests/__snapshots__/syntax-script-vue-javascript
+++ b/tests/__snapshots__/syntax-script-vue-javascript
@@ -11,7 +11,7 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "eslint-plugin-vue",
   ],

--- a/tests/__snapshots__/syntax-script-vue-typescript
+++ b/tests/__snapshots__/syntax-script-vue-typescript
@@ -14,13 +14,12 @@ export default [
 ];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
-    "eslint@9.x",
+    "eslint",
     "globals",
     "typescript-eslint",
     "eslint-plugin-vue",
   ],
   "installFlags": [
     "-D",
-    "--force",
   ],
 }


### PR DESCRIPTION
refs: https://typescript-eslint.io/blog/announcing-typescript-eslint-v8

```bash
$ node ../bin/create-config.js
@eslint/create-config: v1.2.0

✔ How would you like to use ESLint? · problems
✔ What type of modules does your project use? · esm
✔ Which framework does your project use? · react
✔ Does your project use TypeScript? · typescript
✔ Where does your code run? · browser
The config that you've selected requires the following dependencies:

eslint, globals, @eslint/js, typescript-eslint, eslint-plugin-react
✔ Would you like to install them now? · No / Yes
✔ Which package manager do you want to use? · npm
☕️Installing...

added 221 packages in 1m

107 packages are looking for funding
  run `npm fund` for details
Successfully created /Users/weiran/repo/github/create-config/example/eslint.config.mjs file.
```