### PR TITLE
test: update test with `eslint-config-xo`

### DIFF
--- a/tests/__snapshots__/config@eslint-config-xo
+++ b/tests/__snapshots__/config@eslint-config-xo
@@ -1,24 +1,14 @@
 {
-  "configContent": "
-import path from "path";
-import { fileURLToPath } from "url";
-import { FlatCompat } from "@eslint/eslintrc";
-import pluginJs from "@eslint/js";
+  "configContent": "import config from "eslint-config-xo";
 
-// mimic CommonJS variables -- not needed if using CommonJS
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: pluginJs.configs.recommended});
 
 export default [
-  ...compat.extends("xo"),
+  ...[].concat(config),
 ];",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
-    "eslint@>=8.56.0",
+    "eslint@>=9.8.0",
     "eslint-config-xo",
-    "@eslint/eslintrc",
-    "@eslint/js",
   ],
   "installFlags": [
     "-D",

--- a/tests/config-snapshots.spec.js
+++ b/tests/config-snapshots.spec.js
@@ -74,7 +74,7 @@ describe("generate config for cjs projects", () => {
     const inputs = [{
         name: "config@eslint-config-xo",
         answers: {
-            config: { packageName: "eslint-config-xo", type: "eslintrc" }
+            config: { packageName: "eslint-config-xo", type: "flat" }
         }
     },
     {


### PR DESCRIPTION
The latest version of `eslint-config-xo` supports ESLint v9 and exports flat config format:

https://github.com/xojs/eslint-config-xo/releases/tag/v0.46.0

It currently breaks CI on the main branch:

https://github.com/eslint/create-config/actions/runs/10234823210/job/28314801941

This updates a test with `eslint-config-xo` to not use `--eslintrc`, and updates the corresponding snapshot accordingly.