### PR TITLE
feat: avoid empty config warning

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -231,7 +231,7 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: plug
         this.result.configContent = `${importContent}
 ${needCompatHelper ? helperContent : ""}
 /** @type {import('eslint').Linter.Config[]} */
-export default [\n${exportContent}];`;
+export default [\n${exportContent || "  {}\n"}];`; // defaults to `[{}]` to avoid empty config warning
     }
 
     /**

--- a/tests/__snapshots__/empty
+++ b/tests/__snapshots__/empty
@@ -1,0 +1,15 @@
+{
+  "configContent": "
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [
+  {}
+];",
+  "configFilename": "eslint.config.js",
+  "devDependencies": [
+    "eslint",
+  ],
+  "installFlags": [
+    "-D",
+  ],
+}

--- a/tests/config-snapshots.spec.js
+++ b/tests/config-snapshots.spec.js
@@ -52,9 +52,8 @@ describe("generate config for esm projects", () => {
             purpose: "syntax",
             moduleType: "esm",
             framework: "none",
-            language: "javascript"
-
-            // no env
+            language: "javascript",
+            env: []
         }
     });
 

--- a/tests/config-snapshots.spec.js
+++ b/tests/config-snapshots.spec.js
@@ -45,6 +45,19 @@ describe("generate config for esm projects", () => {
         }
     }
 
+    // add a combination that should produce an empty config
+    inputs.push({
+        name: "empty",
+        answers: {
+            purpose: "syntax",
+            moduleType: "esm",
+            framework: "none",
+            language: "javascript"
+
+            // no env
+        }
+    });
+
     inputs.forEach(item => {
         test(`${item.name}`, () => {
             const generator = new ConfigGenerator({ cwd: esmProjectDir, answers: item.answers });


### PR DESCRIPTION
As of v9.20.0, ESLint emits a warning when the config file exports an empty array.

This PR updates the output to export `[{}]` instead of `[]` when the config file is intentionally empty as the result of answers (e.g., https://github.com/eslint/eslint/issues/19044#issuecomment-2449269368) in order to avoid the warning.