### PR TITLE
feat: add fallback to npm registry API in fetchPeerDependencies

### DIFF
--- a/bin/create-config.js
+++ b/bin/create-config.js
@@ -29,7 +29,7 @@ if (sharedConfigIndex === -1) {
     const generator = new ConfigGenerator({ cwd, packageJsonPath });
 
     await generator.prompt();
-    generator.calc();
+    await generator.calc();
     await generator.output();
 } else {
 
@@ -39,6 +39,6 @@ if (sharedConfigIndex === -1) {
     const answers = { config: { packageName, type } };
     const generator = new ConfigGenerator({ cwd, packageJsonPath, answers });
 
-    generator.calc();
+    await generator.calc();
     await generator.output();
 }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -105,7 +105,7 @@ export class ConfigGenerator {
      * Calculate the configuration based on the user's answers.
      * @returns {void}
      */
-    calc() {
+    async calc() {
         const isESMModule = isPackageTypeModule(this.packageJsonPath);
 
         this.result.configFilename = isESMModule ? "eslint.config.js" : "eslint.config.mjs";
@@ -190,7 +190,7 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: plug
             this.result.devDependencies.push(config.packageName);
 
             // install peer dependencies - it's needed for most eslintrc-style shared configs.
-            const peers = fetchPeerDependencies(config.packageName);
+            const peers = await fetchPeerDependencies(config.packageName);
 
             if (peers !== null) {
                 const eslintIndex = peers.findIndex(dep => (dep.startsWith("eslint@")));

--- a/lib/utils/npm-utils.js
+++ b/lib/utils/npm-utils.js
@@ -10,7 +10,7 @@
 
 import fs from "node:fs";
 import spawn from "cross-spawn";
-
+import https from "node:https";
 import path from "node:path";
 import * as log from "./logging.js";
 
@@ -64,11 +64,29 @@ function installSyncSaveDev(packages, packageManager = "npm", installFlags = ["-
 }
 
 /**
+ * Parses a package name string into its name and version components.
+ * @param {string} packageName The package name to parse.
+ * @returns {Object} An object with 'name' and 'version' properties.
+ */
+function parsePackageName(packageName) {
+    const atIndex = packageName.lastIndexOf("@");
+
+    if (atIndex > 0) {
+        const name = packageName.slice(0, atIndex);
+        const version = packageName.slice(atIndex + 1) || "latest";
+
+        return { name, version };
+    }
+    return { name: packageName, version: "latest" };
+
+}
+
+/**
  * Fetch `peerDependencies` of the given package by `npm show` command.
  * @param {string} packageName The package name to fetch peerDependencies.
  * @returns {Object} Gotten peerDependencies. Returns null if npm was not found.
  */
-function fetchPeerDependencies(packageName) {
+async function fetchPeerDependencies(packageName) {
     const npmProcess = spawn.sync(
         "npm",
         ["show", "--json", packageName, "peerDependencies"],
@@ -79,8 +97,47 @@ function fetchPeerDependencies(packageName) {
 
     if (error && error.code === "ENOENT") {
 
-        // TODO: should throw an error instead of returning null
-        return null;
+        // Fallback to using the npm registry API directly when npm is not available.
+        const { name, version } = parsePackageName(packageName);
+
+        try {
+            const data = await new Promise((resolve, reject) => {
+                https.get(`https://registry.npmjs.org/${name}`, res => {
+                    let rawData = "";
+
+                    res.on("data", chunk => {
+                        rawData += chunk;
+                    });
+                    res.on("end", () => {
+                        try {
+                            const parsedData = JSON.parse(rawData);
+
+                            resolve(parsedData);
+                        } catch (parseError) {
+                            reject(parseError);
+                        }
+                    });
+                    res.on("error", reject);
+                });
+            });
+
+            const resolvedVersion =
+        version === "latest" ? data["dist-tags"]?.latest : version;
+            const packageVersion = data.versions[resolvedVersion];
+
+            if (!packageVersion) {
+                throw new Error(
+                    `Version "${version}" not found for package "${name}".`
+                );
+            }
+            return Object.entries(packageVersion.peerDependencies).map(
+                ([pkgName, pkgVersion]) => `${pkgName}@${pkgVersion}`
+            );
+        } catch {
+
+            // TODO: should throw an error instead of returning null
+            return null;
+        }
     }
     const fetchedText = npmProcess.stdout.trim();
 
@@ -188,6 +245,7 @@ function isPackageTypeModule(pkgJSONPath) {
 
 export {
     installSyncSaveDev,
+    parsePackageName,
     fetchPeerDependencies,
     findPackageJson,
     checkDeps,

--- a/lib/utils/npm-utils.js
+++ b/lib/utils/npm-utils.js
@@ -10,7 +10,6 @@
 
 import fs from "node:fs";
 import spawn from "cross-spawn";
-import https from "node:https";
 import path from "node:path";
 import * as log from "./logging.js";
 
@@ -101,25 +100,9 @@ async function fetchPeerDependencies(packageName) {
         const { name, version } = parsePackageName(packageName);
 
         try {
-            const data = await new Promise((resolve, reject) => {
-                https.get(`https://registry.npmjs.org/${name}`, res => {
-                    let rawData = "";
-
-                    res.on("data", chunk => {
-                        rawData += chunk;
-                    });
-                    res.on("end", () => {
-                        try {
-                            const parsedData = JSON.parse(rawData);
-
-                            resolve(parsedData);
-                        } catch (parseError) {
-                            reject(parseError);
-                        }
-                    });
-                    res.on("error", reject);
-                });
-            });
+            // eslint-disable-next-line n/no-unsupported-features/node-builtins -- Fallback using built-in fetch
+            const response = await fetch(`https://registry.npmjs.org/${name}`);
+            const data = await response.json();
 
             const resolvedVersion =
         version === "latest" ? data["dist-tags"]?.latest : version;

--- a/tests/config-snapshots.spec.js
+++ b/tests/config-snapshots.spec.js
@@ -58,10 +58,10 @@ describe("generate config for esm projects", () => {
     });
 
     inputs.forEach(item => {
-        test(`${item.name}`, () => {
+        test(`${item.name}`, async () => {
             const generator = new ConfigGenerator({ cwd: esmProjectDir, answers: item.answers });
 
-            generator.calc();
+            await generator.calc();
 
             expect(generator.result.configFilename).toBe("eslint.config.js");
             expect(generator.packageJsonPath).toBe(join(esmProjectDir, "./package.json"));
@@ -69,11 +69,11 @@ describe("generate config for esm projects", () => {
         });
     });
 
-    test("sub dir", () => {
+    test("sub dir", async () => {
         const sub = join(__filename, "../fixtures/esm-project/sub");
         const generator = new ConfigGenerator({ cwd: sub, answers: { purpose: "problems", moduleType: "esm", framework: "none", language: "javascript", env: ["node"] } });
 
-        generator.calc();
+        await generator.calc();
 
         expect(generator.result.configFilename).toBe("eslint.config.js");
         expect(generator.packageJsonPath).toBe(join(esmProjectDir, "./package.json"));
@@ -117,10 +117,10 @@ describe("generate config for cjs projects", () => {
     }];
 
     inputs.forEach(item => {
-        test(`${item.name}`, () => {
+        test(`${item.name}`, async () => {
             const generator = new ConfigGenerator({ cwd: cjsProjectDir, answers: item.answers });
 
-            generator.calc();
+            await generator.calc();
 
             expect(generator.result.configFilename).toBe("eslint.config.mjs");
             expect(generator.packageJsonPath).toBe(join(cjsProjectDir, "./package.json"));

--- a/tests/utils/npm-utils.spec.js
+++ b/tests/utils/npm-utils.spec.js
@@ -20,6 +20,7 @@ import {
 import { defineInMemoryFs } from "../_utils/in-memory-fs.js";
 import { assert, describe, afterEach, it } from "vitest";
 import fs from "node:fs";
+import process from "node:process";
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -250,7 +251,9 @@ describe("npmUtils", () => {
             stub.restore();
         });
 
-        it("should fetch peer dependencies from npm registry when npm is not available", async () => {
+        // Skip on Node.js v21 due to a bug where fetch cannot be stubbed
+        // See: https://github.com/sinonjs/sinon/issues/2590
+        it.skipIf(process.version.startsWith("v21"))("should fetch peer dependencies from npm registry when npm is not available", async () => {
             const npmStub = sinon.stub(spawn, "sync").returns({ error: { code: "ENOENT" } });
             const fetchStub = sinon.stub(globalThis, "fetch");
 


### PR DESCRIPTION
This PR enhances the `fetchPeerDependencies` function by adding a fallback mechanism. If `npm` is unavailable, the function will now query the npm registry API directly to fetch peer dependencies.

Closes #84