### PR TITLE
feat: Output defineConfig in file

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -230,7 +230,6 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
 
         this.result.configContent = `${importContent}
 ${needCompatHelper ? helperContent : ""}
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([\n${exportContent || "  {}\n"}]);`; // defaults to `[{}]` to avoid empty config warning
     }
 

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -2,6 +2,11 @@
  * @fileoverview to generate config files.
  * @author 唯然<weiran.zsd@outlook.com>
  */
+
+//-----------------------------------------------------------------------------
+// Imports
+//-----------------------------------------------------------------------------
+
 import process from "node:process";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
@@ -10,6 +15,41 @@ import enquirer from "enquirer";
 import { isPackageTypeModule, installSyncSaveDev, fetchPeerDependencies, findPackageJson } from "./utils/npm-utils.js";
 import { getShorthandName } from "./utils/naming.js";
 import * as log from "./utils/logging.js";
+
+//-----------------------------------------------------------------------------
+// Helpers
+//-----------------------------------------------------------------------------
+
+/**
+ * Get the file extensions to lint based on the user's answers.
+ * @param {Object} answers The answers provided by the user.
+ * @returns {string[]} The file extensions to lint.
+ */
+function getExtensions(answers) {
+    const extensions = ["js", "mjs", "cjs"];
+
+    if (answers.language === "typescript") {
+        extensions.push("ts");
+    }
+
+    if (answers.framework === "vue") {
+        extensions.push("vue");
+    }
+
+    if (answers.framework === "react") {
+        extensions.push("jsx");
+
+        if (answers.language === "typescript") {
+            extensions.push("tsx");
+        }
+    }
+
+    return extensions;
+}
+
+//-----------------------------------------------------------------------------
+// Exports
+//-----------------------------------------------------------------------------
 
 /**
  * Class representing a ConfigGenerator.
@@ -112,7 +152,7 @@ export class ConfigGenerator {
         this.answers.config = typeof this.answers.config === "string"
             ? { packageName: this.answers.config, type: "flat" }
             : this.answers.config;
-        const extensions = []; // file extensions to lint, the default is ["js", "mjs", "cjs"]
+        const extensions = `**/*.{${getExtensions(this.answers)}}`;
 
         let importContent = "import { defineConfig } from \"eslint/config\";\n";
         const helperContent = `import path from "node:path";
@@ -141,7 +181,7 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
                 "browser,node": "globals: {...globals.browser, ...globals.node}"
             };
 
-            exportContent += `  { files: ["**/*.js"], languageOptions: { ${envContent[this.answers.env.join(",")]} } },\n`;
+            exportContent += `  { files: ["${extensions}"], languageOptions: { ${envContent[this.answers.env.join(",")]} } },\n`;
         }
 
         if (this.answers.purpose === "syntax") {
@@ -150,35 +190,27 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
         } else if (this.answers.purpose === "problems") {
             this.result.devDependencies.push("@eslint/js");
             importContent += "import js from \"@eslint/js\";\n";
-            exportContent += "  { files: [\"**/*.js\"], plugins: { js }, extends: [\"js/recommended\"] },\n";
+            exportContent += `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended"] },\n`;
         }
 
         if (this.answers.language === "typescript") {
-            extensions.push("ts");
             this.result.devDependencies.push("typescript-eslint");
             importContent += "import tseslint from \"typescript-eslint\";\n";
             exportContent += "  tseslint.configs.recommended,\n";
         }
 
         if (this.answers.framework === "vue") {
-            extensions.push("vue");
             this.result.devDependencies.push("eslint-plugin-vue");
             importContent += "import pluginVue from \"eslint-plugin-vue\";\n";
             exportContent += "  pluginVue.configs[\"flat/essential\"],\n";
 
             // https://eslint.vuejs.org/user-guide/#how-to-use-a-custom-parser
             if (this.answers.language === "typescript") {
-                exportContent += "  {files: [\"**/*.vue\"], languageOptions: { parserOptions: { parser: tseslint.parser } } },\n";
+                exportContent += "  { files: [\"**/*.vue\"], languageOptions: { parserOptions: { parser: tseslint.parser } } },\n";
             }
         }
 
         if (this.answers.framework === "react") {
-            extensions.push("jsx");
-
-            if (this.answers.language === "typescript") {
-                extensions.push("tsx");
-            }
-
             this.result.devDependencies.push("eslint-plugin-react");
             importContent += "import pluginReact from \"eslint-plugin-react\";\n";
             exportContent += "  pluginReact.configs.flat.recommended,\n";
@@ -224,7 +256,7 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
             this.result.devDependencies.push("@eslint/eslintrc", "@eslint/js");
         }
 
-        const lintFilesConfig = extensions.length > 0 ? `  { files: ["**/*.{${["js", "mjs", "cjs", ...extensions]}}"] },\n` : "";
+        const lintFilesConfig = `  { files: ["${extensions}"] },\n`;
 
         exportContent = `${lintFilesConfig}${exportContent}`;
 

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -114,22 +114,22 @@ export class ConfigGenerator {
             : this.answers.config;
         const extensions = []; // file extensions to lint, the default is ["js", "mjs", "cjs"]
 
-        let importContent = "";
-        const helperContent = `import path from "path";
-import { fileURLToPath } from "url";
+        let importContent = "import { defineConfig } from \"eslint/config\";\n";
+        const helperContent = `import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
-import pluginJs from "@eslint/js";
+import js from "@eslint/js";
 
 // mimic CommonJS variables -- not needed if using CommonJS
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: pluginJs.configs.recommended});
+const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 `;
         let exportContent = "";
         let needCompatHelper = false;
 
         if (this.answers.moduleType === "commonjs" || this.answers.moduleType === "script") {
-            exportContent += `  {files: ["**/*.js"], languageOptions: {sourceType: "${this.answers.moduleType}"}},\n`;
+            exportContent += `  { files: ["**/*.js"], languageOptions: { sourceType: "${this.answers.moduleType}" } },\n`;
         }
 
         if (this.answers.env?.length > 0) {
@@ -141,7 +141,7 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: plug
                 "browser,node": "globals: {...globals.browser, ...globals.node}"
             };
 
-            exportContent += `  {languageOptions: { ${envContent[this.answers.env.join(",")]} }},\n`;
+            exportContent += `  { files: ["**/*.js"], languageOptions: { ${envContent[this.answers.env.join(",")]} } },\n`;
         }
 
         if (this.answers.purpose === "syntax") {
@@ -149,26 +149,26 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: plug
             // no need to install any plugin
         } else if (this.answers.purpose === "problems") {
             this.result.devDependencies.push("@eslint/js");
-            importContent += "import pluginJs from \"@eslint/js\";\n";
-            exportContent += "  pluginJs.configs.recommended,\n";
+            importContent += "import js from \"@eslint/js\";\n";
+            exportContent += "  { files: [\"**/*.js\"], plugins: { js }, extends: [\"js/recommended\"] },\n";
         }
 
         if (this.answers.language === "typescript") {
             extensions.push("ts");
             this.result.devDependencies.push("typescript-eslint");
             importContent += "import tseslint from \"typescript-eslint\";\n";
-            exportContent += "  ...tseslint.configs.recommended,\n";
+            exportContent += "  tseslint.configs.recommended,\n";
         }
 
         if (this.answers.framework === "vue") {
             extensions.push("vue");
             this.result.devDependencies.push("eslint-plugin-vue");
             importContent += "import pluginVue from \"eslint-plugin-vue\";\n";
-            exportContent += "  ...pluginVue.configs[\"flat/essential\"],\n";
+            exportContent += "  pluginVue.configs[\"flat/essential\"],\n";
 
             // https://eslint.vuejs.org/user-guide/#how-to-use-a-custom-parser
             if (this.answers.language === "typescript") {
-                exportContent += "  {files: [\"**/*.vue\"], languageOptions: {parserOptions: {parser: tseslint.parser}}},\n";
+                exportContent += "  {files: [\"**/*.vue\"], languageOptions: { parserOptions: { parser: tseslint.parser } } },\n";
             }
         }
 
@@ -210,13 +210,13 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: plug
 
             if (config.type === "flat" || config.type === void 0) {
                 importContent += `import config from "${config.packageName}";\n`;
-                exportContent += "  ...[].concat(config),\n";
+                exportContent += "  config,\n";
             } else if (config.type === "eslintrc") {
                 needCompatHelper = true;
 
                 const shorthandName = getShorthandName(config.packageName, "eslint-config");
 
-                exportContent += `  ...compat.extends("${shorthandName}"),\n`;
+                exportContent += `  compat.extends("${shorthandName}"),\n`;
             }
         }
 
@@ -224,14 +224,14 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: plug
             this.result.devDependencies.push("@eslint/eslintrc", "@eslint/js");
         }
 
-        const lintFilesConfig = extensions.length > 0 ? `  {files: ["**/*.{${["js", "mjs", "cjs", ...extensions]}}"]},\n` : "";
+        const lintFilesConfig = extensions.length > 0 ? `  { files: ["**/*.{${["js", "mjs", "cjs", ...extensions]}}"] },\n` : "";
 
         exportContent = `${lintFilesConfig}${exportContent}`;
 
         this.result.configContent = `${importContent}
 ${needCompatHelper ? helperContent : ""}
 /** @type {import('eslint').Linter.Config[]} */
-export default [\n${exportContent || "  {}\n"}];`; // defaults to `[{}]` to avoid empty config warning
+export default defineConfig([\n${exportContent || "  {}\n"}]);`; // defaults to `[{}]` to avoid empty config warning
     }
 
     /**

--- a/tests/__snapshots__/config@eslint-config-airbnb
+++ b/tests/__snapshots__/config@eslint-config-airbnb
@@ -1,19 +1,20 @@
 {
-  "configContent": "
-import path from "path";
-import { fileURLToPath } from "url";
+  "configContent": "import { defineConfig } from "eslint/config";
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
-import pluginJs from "@eslint/js";
+import js from "@eslint/js";
 
 // mimic CommonJS variables -- not needed if using CommonJS
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: pluginJs.configs.recommended});
+const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  ...compat.extends("airbnb"),
-];",
+export default defineConfig([
+  compat.extends("airbnb"),
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^7.32.0 || ^8.2.0",

--- a/tests/__snapshots__/config@eslint-config-airbnb
+++ b/tests/__snapshots__/config@eslint-config-airbnb
@@ -11,7 +11,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   compat.extends("airbnb"),
 ]);",

--- a/tests/__snapshots__/config@eslint-config-airbnb
+++ b/tests/__snapshots__/config@eslint-config-airbnb
@@ -12,6 +12,7 @@ const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
 export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"] },
   compat.extends("airbnb"),
 ]);",
   "configFilename": "eslint.config.mjs",

--- a/tests/__snapshots__/config@eslint-config-airbnb-base
+++ b/tests/__snapshots__/config@eslint-config-airbnb-base
@@ -1,19 +1,20 @@
 {
-  "configContent": "
-import path from "path";
-import { fileURLToPath } from "url";
+  "configContent": "import { defineConfig } from "eslint/config";
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
-import pluginJs from "@eslint/js";
+import js from "@eslint/js";
 
 // mimic CommonJS variables -- not needed if using CommonJS
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: pluginJs.configs.recommended});
+const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  ...compat.extends("airbnb-base"),
-];",
+export default defineConfig([
+  compat.extends("airbnb-base"),
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^7.32.0 || ^8.2.0",

--- a/tests/__snapshots__/config@eslint-config-airbnb-base
+++ b/tests/__snapshots__/config@eslint-config-airbnb-base
@@ -12,6 +12,7 @@ const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
 export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"] },
   compat.extends("airbnb-base"),
 ]);",
   "configFilename": "eslint.config.mjs",

--- a/tests/__snapshots__/config@eslint-config-airbnb-base
+++ b/tests/__snapshots__/config@eslint-config-airbnb-base
@@ -11,7 +11,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   compat.extends("airbnb-base"),
 ]);",

--- a/tests/__snapshots__/config@eslint-config-standard
+++ b/tests/__snapshots__/config@eslint-config-standard
@@ -11,7 +11,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   compat.extends("standard"),
 ]);",

--- a/tests/__snapshots__/config@eslint-config-standard
+++ b/tests/__snapshots__/config@eslint-config-standard
@@ -1,19 +1,20 @@
 {
-  "configContent": "
-import path from "path";
-import { fileURLToPath } from "url";
+  "configContent": "import { defineConfig } from "eslint/config";
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
-import pluginJs from "@eslint/js";
+import js from "@eslint/js";
 
 // mimic CommonJS variables -- not needed if using CommonJS
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: pluginJs.configs.recommended});
+const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  ...compat.extends("standard"),
-];",
+export default defineConfig([
+  compat.extends("standard"),
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard
+++ b/tests/__snapshots__/config@eslint-config-standard
@@ -12,6 +12,7 @@ const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
 export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"] },
   compat.extends("standard"),
 ]);",
   "configFilename": "eslint.config.mjs",

--- a/tests/__snapshots__/config@eslint-config-standard-flat
+++ b/tests/__snapshots__/config@eslint-config-standard-flat
@@ -4,6 +4,7 @@ import config from "eslint-config-standard";
 
 
 export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"] },
   config,
 ]);",
   "configFilename": "eslint.config.mjs",

--- a/tests/__snapshots__/config@eslint-config-standard-flat
+++ b/tests/__snapshots__/config@eslint-config-standard-flat
@@ -1,11 +1,12 @@
 {
-  "configContent": "import config from "eslint-config-standard";
+  "configContent": "import { defineConfig } from "eslint/config";
+import config from "eslint-config-standard";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  ...[].concat(config),
-];",
+export default defineConfig([
+  config,
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard-flat
+++ b/tests/__snapshots__/config@eslint-config-standard-flat
@@ -3,7 +3,6 @@
 import config from "eslint-config-standard";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   config,
 ]);",

--- a/tests/__snapshots__/config@eslint-config-standard-flat2
+++ b/tests/__snapshots__/config@eslint-config-standard-flat2
@@ -4,6 +4,7 @@ import config from "eslint-config-standard";
 
 
 export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"] },
   config,
 ]);",
   "configFilename": "eslint.config.mjs",

--- a/tests/__snapshots__/config@eslint-config-standard-flat2
+++ b/tests/__snapshots__/config@eslint-config-standard-flat2
@@ -1,11 +1,12 @@
 {
-  "configContent": "import config from "eslint-config-standard";
+  "configContent": "import { defineConfig } from "eslint/config";
+import config from "eslint-config-standard";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  ...[].concat(config),
-];",
+export default defineConfig([
+  config,
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard-flat2
+++ b/tests/__snapshots__/config@eslint-config-standard-flat2
@@ -3,7 +3,6 @@
 import config from "eslint-config-standard";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   config,
 ]);",

--- a/tests/__snapshots__/config@eslint-config-xo
+++ b/tests/__snapshots__/config@eslint-config-xo
@@ -1,11 +1,12 @@
 {
-  "configContent": "import config from "eslint-config-xo";
+  "configContent": "import { defineConfig } from "eslint/config";
+import config from "eslint-config-xo";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  ...[].concat(config),
-];",
+export default defineConfig([
+  config,
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@>=9.8.0",

--- a/tests/__snapshots__/config@eslint-config-xo
+++ b/tests/__snapshots__/config@eslint-config-xo
@@ -3,7 +3,6 @@
 import config from "eslint-config-xo";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   config,
 ]);",

--- a/tests/__snapshots__/config@eslint-config-xo
+++ b/tests/__snapshots__/config@eslint-config-xo
@@ -4,6 +4,7 @@ import config from "eslint-config-xo";
 
 
 export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"] },
   config,
 ]);",
   "configFilename": "eslint.config.mjs",

--- a/tests/__snapshots__/empty
+++ b/tests/__snapshots__/empty
@@ -2,7 +2,6 @@
   "configContent": "import { defineConfig } from "eslint/config";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   {}
 ]);",

--- a/tests/__snapshots__/empty
+++ b/tests/__snapshots__/empty
@@ -3,7 +3,7 @@
 
 
 export default defineConfig([
-  {}
+  { files: ["**/*.{js,mjs,cjs}"] },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/empty
+++ b/tests/__snapshots__/empty
@@ -1,10 +1,11 @@
 {
-  "configContent": "
+  "configContent": "import { defineConfig } from "eslint/config";
+
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
+export default defineConfig([
   {}
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-none-javascript
+++ b/tests/__snapshots__/problems-commonjs-none-javascript
@@ -5,9 +5,10 @@ import js from "@eslint/js";
 
 
 export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/problems-commonjs-none-javascript
+++ b/tests/__snapshots__/problems-commonjs-none-javascript
@@ -1,14 +1,15 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-];",
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-none-javascript
+++ b/tests/__snapshots__/problems-commonjs-none-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import js from "@eslint/js";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -5,7 +5,6 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -8,8 +8,8 @@ import tseslint from "typescript-eslint";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -1,17 +1,18 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  tseslint.configs.recommended,
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-react-javascript
+++ b/tests/__snapshots__/problems-commonjs-react-javascript
@@ -8,8 +8,8 @@ import pluginReact from "eslint-plugin-react";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-commonjs-react-javascript
+++ b/tests/__snapshots__/problems-commonjs-react-javascript
@@ -1,17 +1,18 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,jsx}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,jsx}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-react-javascript
+++ b/tests/__snapshots__/problems-commonjs-react-javascript
@@ -5,7 +5,6 @@ import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -6,7 +6,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -1,19 +1,20 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -9,8 +9,8 @@ import pluginReact from "eslint-plugin-react";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);",

--- a/tests/__snapshots__/problems-commonjs-vue-javascript
+++ b/tests/__snapshots__/problems-commonjs-vue-javascript
@@ -5,7 +5,6 @@ import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/problems-commonjs-vue-javascript
+++ b/tests/__snapshots__/problems-commonjs-vue-javascript
@@ -1,17 +1,18 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,vue}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...pluginVue.configs["flat/essential"],
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,vue}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  pluginVue.configs["flat/essential"],
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-vue-javascript
+++ b/tests/__snapshots__/problems-commonjs-vue-javascript
@@ -8,8 +8,8 @@ import pluginVue from "eslint-plugin-vue";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   pluginVue.configs["flat/essential"],
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -6,7 +6,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -1,20 +1,21 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,vue}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
-  ...pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  tseslint.configs.recommended,
+  pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -9,11 +9,11 @@ import pluginVue from "eslint-plugin-vue";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+  { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/problems-esm-none-javascript
+++ b/tests/__snapshots__/problems-esm-none-javascript
@@ -1,13 +1,14 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-];",
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-none-javascript
+++ b/tests/__snapshots__/problems-esm-none-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import js from "@eslint/js";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },

--- a/tests/__snapshots__/problems-esm-none-javascript
+++ b/tests/__snapshots__/problems-esm-none-javascript
@@ -5,8 +5,9 @@ import js from "@eslint/js";
 
 
 export default defineConfig([
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs}"] },
+  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -7,8 +7,8 @@ import tseslint from "typescript-eslint";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -1,16 +1,17 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts}"] },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  tseslint.configs.recommended,
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -5,7 +5,6 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/problems-esm-react-javascript
+++ b/tests/__snapshots__/problems-esm-react-javascript
@@ -5,7 +5,6 @@ import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/problems-esm-react-javascript
+++ b/tests/__snapshots__/problems-esm-react-javascript
@@ -7,8 +7,8 @@ import pluginReact from "eslint-plugin-react";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-esm-react-javascript
+++ b/tests/__snapshots__/problems-esm-react-javascript
@@ -1,16 +1,17 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,jsx}"]},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,jsx}"] },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -6,7 +6,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -1,18 +1,19 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"]},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -8,8 +8,8 @@ import pluginReact from "eslint-plugin-react";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);",

--- a/tests/__snapshots__/problems-esm-vue-javascript
+++ b/tests/__snapshots__/problems-esm-vue-javascript
@@ -5,7 +5,6 @@ import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/problems-esm-vue-javascript
+++ b/tests/__snapshots__/problems-esm-vue-javascript
@@ -1,16 +1,17 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,vue}"]},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...pluginVue.configs["flat/essential"],
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,vue}"] },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  pluginVue.configs["flat/essential"],
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-vue-javascript
+++ b/tests/__snapshots__/problems-esm-vue-javascript
@@ -7,8 +7,8 @@ import pluginVue from "eslint-plugin-vue";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   pluginVue.configs["flat/essential"],
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -8,11 +8,11 @@ import pluginVue from "eslint-plugin-vue";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+  { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -6,7 +6,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -1,19 +1,20 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,vue}"]},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
-  ...pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  tseslint.configs.recommended,
+  pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-none-javascript
+++ b/tests/__snapshots__/problems-script-none-javascript
@@ -5,9 +5,10 @@ import js from "@eslint/js";
 
 
 export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/problems-script-none-javascript
+++ b/tests/__snapshots__/problems-script-none-javascript
@@ -1,14 +1,15 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-];",
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-none-javascript
+++ b/tests/__snapshots__/problems-script-none-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import js from "@eslint/js";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -5,7 +5,6 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -8,8 +8,8 @@ import tseslint from "typescript-eslint";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -1,17 +1,18 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  tseslint.configs.recommended,
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-react-javascript
+++ b/tests/__snapshots__/problems-script-react-javascript
@@ -5,7 +5,6 @@ import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/problems-script-react-javascript
+++ b/tests/__snapshots__/problems-script-react-javascript
@@ -1,17 +1,18 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,jsx}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,jsx}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-react-javascript
+++ b/tests/__snapshots__/problems-script-react-javascript
@@ -8,8 +8,8 @@ import pluginReact from "eslint-plugin-react";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -9,8 +9,8 @@ import pluginReact from "eslint-plugin-react";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);",

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -1,19 +1,20 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -6,7 +6,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/problems-script-vue-javascript
+++ b/tests/__snapshots__/problems-script-vue-javascript
@@ -8,8 +8,8 @@ import pluginVue from "eslint-plugin-vue";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   pluginVue.configs["flat/essential"],
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-script-vue-javascript
+++ b/tests/__snapshots__/problems-script-vue-javascript
@@ -5,7 +5,6 @@ import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/problems-script-vue-javascript
+++ b/tests/__snapshots__/problems-script-vue-javascript
@@ -1,17 +1,18 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,vue}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...pluginVue.configs["flat/essential"],
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,vue}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  pluginVue.configs["flat/essential"],
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -9,11 +9,11 @@ import pluginVue from "eslint-plugin-vue";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+  { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -6,7 +6,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -1,20 +1,21 @@
 {
-  "configContent": "import globals from "globals";
-import pluginJs from "@eslint/js";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
+import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,vue}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  pluginJs.configs.recommended,
-  ...tseslint.configs.recommended,
-  ...pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.js"], plugins: { js }, extends: ["js/recommended"] },
+  tseslint.configs.recommended,
+  pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-none-javascript
+++ b/tests/__snapshots__/syntax-commonjs-none-javascript
@@ -3,7 +3,6 @@
 import globals from "globals";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-commonjs-none-javascript
+++ b/tests/__snapshots__/syntax-commonjs-none-javascript
@@ -4,8 +4,9 @@ import globals from "globals";
 
 
 export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/syntax-commonjs-none-javascript
+++ b/tests/__snapshots__/syntax-commonjs-none-javascript
@@ -1,12 +1,13 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-];",
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-none-typescript
+++ b/tests/__snapshots__/syntax-commonjs-none-typescript
@@ -7,7 +7,7 @@ import tseslint from "typescript-eslint";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-commonjs-none-typescript
+++ b/tests/__snapshots__/syntax-commonjs-none-typescript
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/syntax-commonjs-none-typescript
+++ b/tests/__snapshots__/syntax-commonjs-none-typescript
@@ -1,15 +1,16 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...tseslint.configs.recommended,
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  tseslint.configs.recommended,
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-javascript
+++ b/tests/__snapshots__/syntax-commonjs-react-javascript
@@ -7,7 +7,7 @@ import pluginReact from "eslint-plugin-react";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-commonjs-react-javascript
+++ b/tests/__snapshots__/syntax-commonjs-react-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/syntax-commonjs-react-javascript
+++ b/tests/__snapshots__/syntax-commonjs-react-javascript
@@ -1,15 +1,16 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,jsx}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,jsx}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-typescript
+++ b/tests/__snapshots__/syntax-commonjs-react-typescript
@@ -1,17 +1,18 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...tseslint.configs.recommended,
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-typescript
+++ b/tests/__snapshots__/syntax-commonjs-react-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/syntax-commonjs-react-typescript
+++ b/tests/__snapshots__/syntax-commonjs-react-typescript
@@ -8,7 +8,7 @@ import pluginReact from "eslint-plugin-react";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);",

--- a/tests/__snapshots__/syntax-commonjs-vue-javascript
+++ b/tests/__snapshots__/syntax-commonjs-vue-javascript
@@ -7,7 +7,7 @@ import pluginVue from "eslint-plugin-vue";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-commonjs-vue-javascript
+++ b/tests/__snapshots__/syntax-commonjs-vue-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/syntax-commonjs-vue-javascript
+++ b/tests/__snapshots__/syntax-commonjs-vue-javascript
@@ -1,15 +1,16 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,vue}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...pluginVue.configs["flat/essential"],
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,vue}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  pluginVue.configs["flat/essential"],
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-vue-typescript
+++ b/tests/__snapshots__/syntax-commonjs-vue-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/syntax-commonjs-vue-typescript
+++ b/tests/__snapshots__/syntax-commonjs-vue-typescript
@@ -1,18 +1,19 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,vue}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "commonjs"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...tseslint.configs.recommended,
-  ...pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  tseslint.configs.recommended,
+  pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-vue-typescript
+++ b/tests/__snapshots__/syntax-commonjs-vue-typescript
@@ -8,10 +8,10 @@ import pluginVue from "eslint-plugin-vue";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+  { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/syntax-esm-none-javascript
+++ b/tests/__snapshots__/syntax-esm-none-javascript
@@ -4,7 +4,8 @@ import globals from "globals";
 
 
 export default defineConfig([
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs}"] },
+  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/syntax-esm-none-javascript
+++ b/tests/__snapshots__/syntax-esm-none-javascript
@@ -1,11 +1,12 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-];",
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-none-javascript
+++ b/tests/__snapshots__/syntax-esm-none-javascript
@@ -3,7 +3,6 @@
 import globals from "globals";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
 ]);",

--- a/tests/__snapshots__/syntax-esm-none-typescript
+++ b/tests/__snapshots__/syntax-esm-none-typescript
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-esm-none-typescript
+++ b/tests/__snapshots__/syntax-esm-none-typescript
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-esm-none-typescript
+++ b/tests/__snapshots__/syntax-esm-none-typescript
@@ -1,14 +1,15 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...tseslint.configs.recommended,
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts}"] },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  tseslint.configs.recommended,
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-javascript
+++ b/tests/__snapshots__/syntax-esm-react-javascript
@@ -1,14 +1,15 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,jsx}"]},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,jsx}"] },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-javascript
+++ b/tests/__snapshots__/syntax-esm-react-javascript
@@ -6,7 +6,7 @@ import pluginReact from "eslint-plugin-react";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-esm-react-javascript
+++ b/tests/__snapshots__/syntax-esm-react-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-esm-react-typescript
+++ b/tests/__snapshots__/syntax-esm-react-typescript
@@ -7,7 +7,7 @@ import pluginReact from "eslint-plugin-react";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);",

--- a/tests/__snapshots__/syntax-esm-react-typescript
+++ b/tests/__snapshots__/syntax-esm-react-typescript
@@ -1,16 +1,17 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"]},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...tseslint.configs.recommended,
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-typescript
+++ b/tests/__snapshots__/syntax-esm-react-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-esm-vue-javascript
+++ b/tests/__snapshots__/syntax-esm-vue-javascript
@@ -6,7 +6,7 @@ import pluginVue from "eslint-plugin-vue";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-esm-vue-javascript
+++ b/tests/__snapshots__/syntax-esm-vue-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-esm-vue-javascript
+++ b/tests/__snapshots__/syntax-esm-vue-javascript
@@ -1,14 +1,15 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,vue}"]},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...pluginVue.configs["flat/essential"],
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,vue}"] },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  pluginVue.configs["flat/essential"],
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-vue-typescript
+++ b/tests/__snapshots__/syntax-esm-vue-typescript
@@ -7,10 +7,10 @@ import pluginVue from "eslint-plugin-vue";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+  { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/syntax-esm-vue-typescript
+++ b/tests/__snapshots__/syntax-esm-vue-typescript
@@ -1,17 +1,18 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,vue}"]},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...tseslint.configs.recommended,
-  ...pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  tseslint.configs.recommended,
+  pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-vue-typescript
+++ b/tests/__snapshots__/syntax-esm-vue-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-script-none-javascript
+++ b/tests/__snapshots__/syntax-script-none-javascript
@@ -1,12 +1,13 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-];",
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-none-javascript
+++ b/tests/__snapshots__/syntax-script-none-javascript
@@ -3,7 +3,6 @@
 import globals from "globals";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-script-none-javascript
+++ b/tests/__snapshots__/syntax-script-none-javascript
@@ -4,8 +4,9 @@ import globals from "globals";
 
 
 export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [

--- a/tests/__snapshots__/syntax-script-none-typescript
+++ b/tests/__snapshots__/syntax-script-none-typescript
@@ -7,7 +7,7 @@ import tseslint from "typescript-eslint";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-script-none-typescript
+++ b/tests/__snapshots__/syntax-script-none-typescript
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/syntax-script-none-typescript
+++ b/tests/__snapshots__/syntax-script-none-typescript
@@ -1,15 +1,16 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...tseslint.configs.recommended,
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  tseslint.configs.recommended,
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-react-javascript
+++ b/tests/__snapshots__/syntax-script-react-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/syntax-script-react-javascript
+++ b/tests/__snapshots__/syntax-script-react-javascript
@@ -1,15 +1,16 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,jsx}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,jsx}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-react-javascript
+++ b/tests/__snapshots__/syntax-script-react-javascript
@@ -7,7 +7,7 @@ import pluginReact from "eslint-plugin-react";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-script-react-typescript
+++ b/tests/__snapshots__/syntax-script-react-typescript
@@ -8,7 +8,7 @@ import pluginReact from "eslint-plugin-react";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);",

--- a/tests/__snapshots__/syntax-script-react-typescript
+++ b/tests/__snapshots__/syntax-script-react-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/syntax-script-react-typescript
+++ b/tests/__snapshots__/syntax-script-react-typescript
@@ -1,17 +1,18 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...tseslint.configs.recommended,
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-vue-javascript
+++ b/tests/__snapshots__/syntax-script-vue-javascript
@@ -1,15 +1,16 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,vue}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...pluginVue.configs["flat/essential"],
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,vue}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  pluginVue.configs["flat/essential"],
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-vue-javascript
+++ b/tests/__snapshots__/syntax-script-vue-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/syntax-script-vue-javascript
+++ b/tests/__snapshots__/syntax-script-vue-javascript
@@ -7,7 +7,7 @@ import pluginVue from "eslint-plugin-vue";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
 ]);",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/syntax-script-vue-typescript
+++ b/tests/__snapshots__/syntax-script-vue-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-/** @type {import('eslint').Linter.Config[]} */
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/syntax-script-vue-typescript
+++ b/tests/__snapshots__/syntax-script-vue-typescript
@@ -1,18 +1,19 @@
 {
-  "configContent": "import globals from "globals";
+  "configContent": "import { defineConfig } from "eslint/config";
+import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
 /** @type {import('eslint').Linter.Config[]} */
-export default [
-  {files: ["**/*.{js,mjs,cjs,ts,vue}"]},
-  {files: ["**/*.js"], languageOptions: {sourceType: "script"}},
-  {languageOptions: { globals: {...globals.browser, ...globals.node} }},
-  ...tseslint.configs.recommended,
-  ...pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: {parserOptions: {parser: tseslint.parser}}},
-];",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  tseslint.configs.recommended,
+  pluginVue.configs["flat/essential"],
+  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-vue-typescript
+++ b/tests/__snapshots__/syntax-script-vue-typescript
@@ -8,10 +8,10 @@ import pluginVue from "eslint-plugin-vue";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.js"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
-  {files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
+  { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
 ]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [


### PR DESCRIPTION
This updates the command to use `defineConfig()` in the output file. I also cleaned up some of the spacing and switched to `extends` where appropriate.

### Updates to ESLint Configuration Generation:

* Updated imports from `path` and `url` to use `node:path` and `node:url` respectively, and replaced `pluginJs` with `js` from `@eslint/js`. (`lib/config-generator.js`) [[1]](diffhunk://#diff-2eca0c1d89729cbdd3dd2a8364a83357548b45333f6d61ec3afbe42b007e80eeL117-R126) [[2]](diffhunk://#diff-2eca0c1d89729cbdd3dd2a8364a83357548b45333f6d61ec3afbe42b007e80eeL144-R167) [[3]](diffhunk://#diff-2eca0c1d89729cbdd3dd2a8364a83357548b45333f6d61ec3afbe42b007e80eeL213-R219)
* Changed the export format to use `defineConfig` from `eslint/config` instead of array concatenation. (`lib/config-generator.js`)

### Changes in Test Snapshots:

* Updated snapshot files to reflect the new import paths and the use of `defineConfig` for various ESLint configurations. This includes updates for configurations like `eslint-config-airbnb`, `eslint-config-standard`, `eslint-config-xo`, and more. [[1]](diffhunk://#diff-1663862e8c54c128895c2de8b49a30548b1b6c3b5f7c4e1cb0b08e5ccce57d87L2-R17) [[2]](diffhunk://#diff-b8b255ddd2edfd19117be95a7c7e6ac94fffcefbd1a3e37ea0b25091b086dbadL2-R17) [[3]](diffhunk://#diff-94762347bc8ec71379a35501eefb04b78c7bcd139668a22474dd85fa769aba11L2-R17) [[4]](diffhunk://#diff-7d50a965301bb3d86973ed0bcfef72a909110688b4a2578394f3b48f9774c9bfL2-R9) [[5]](diffhunk://#diff-36d2c461b5e9777b34a3854fca65ad8dd76b9a54997a452318bf27c4f6a28f15L2-R9) [[6]](diffhunk://#diff-7f6429eee86278c0c31f913d87bfa0371630f92def221cbb12eae62a04efa954L2-R8) [[7]](diffhunk://#diff-084a7f926640a4bb27cbb18cbf8a6cce4a44f116ede007ddfb760ecbea93043eL2-R12) [[8]](diffhunk://#diff-35b43f887e200b069396afc387ce06829dde04b70cd0fe9f099ca44a6849805bL2-R15) [[9]](diffhunk://#diff-ad1a45f7af93db9527b851ed22939980dca91c5f0202c37047f44b425111eb91L2-R15) [[10]](diffhunk://#diff-8505f716dcb3d4128a60f88f076b76b62af4a25b3b2519dbcd9f8f0ebb8eda89L2-R17) [[11]](diffhunk://#diff-00f60d4884a4505aa095cd8a6c2aa35145d2203db2fe4d5ae5f0ccd9ee8708f1L2-R15) [[12]](diffhunk://#diff-9b3f9c8aa00bbfe85413fb67c539f6f0b730f9627c01c8ec006202ea2e4bfc94L2-R18) [[13]](diffhunk://#diff-e2dc0fdcc1a0bbf1ab39c8ba2cb4a565c238b5f24121d84bcfd3fe683ec7f90bL2-R11) [[14]](diffhunk://#diff-13ab3f5dd4508e045a5b3538f5d33cb111ab23778496676bcac3676a84086bbdL2-R14) [[15]](diffhunk://#diff-8aee48e2c96f344d7d5e7802274be16389a32e0a914e4dc4ba3faa320d5d268bL2-R14) [[16]](diffhunk://#diff-89c051c2b1da3120f9120f9d4cde18043ab2a5924d7191f341794979b33ff33cL2-R16)

These changes ensure that the ESLint configuration generation is up-to-date with the latest standards and improve the maintainability of the codebase.