### PR TITLE
fix: correct `defineConfig` usage in generated config

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -245,7 +245,6 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
                     this.result.devDependencies.push(...peers);
                 } else {
                     const versionMatch = peers[eslintIndex].match(/eslint@(.+)/u);
-                    console.log("🚀 ~ ConfigGenerator ~ calc ~ versionMatch:", versionMatch)
                     const versionRequirement = versionMatch[1]; // Complete version requirement string
                     
                     // Check if the version requirement allows for ESLint 9+                    

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -12,6 +12,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import enquirer from "enquirer";
+import semverSatisfies from "semver/functions/satisfies";
 import { isPackageTypeModule, installSyncSaveDev, fetchPeerDependencies, findPackageJson } from "./utils/npm-utils.js";
 import { getShorthandName } from "./utils/naming.js";
 import * as log from "./utils/logging.js";
@@ -20,17 +21,6 @@ import { langQuestions, jsQuestions, mdQuestions, installationQuestions } from "
 //-----------------------------------------------------------------------------
 // Helpers
 //-----------------------------------------------------------------------------
-
-/**
- * Regular expression to check if a version requirement allows ESLint 9.22.0 or higher.
- * Matches:
- * - "^9" (any ^9.x.x version)
- * - ">=9" (version 9.0.0 or higher)
- * - "~9.22" or higher minor versions (9.22.x and above)
- * - "9.22" or higher versions without prefix
- * - Correctly handles full semver notation (e.g., 9.22.0, ~9.22.0)
- */
-const ESLINT_9_PLUS_REGEX = /\^9|>=\s*9|(?:~|^)9\.(2[2-9]|[3-9]\d|\d{3,})/u;
 
 /**
  * Get the file extensions to lint based on the user's answers.
@@ -260,21 +250,8 @@ export class ConfigGenerator {
                     const versionMatch = peers[eslintIndex].match(/eslint@(.+)/u);
                     const versionRequirement = versionMatch[1]; // Complete version requirement string
 
-                    // Check if the version requirement allows for ESLint 9+
-                    // Handle complex version ranges with "||"
-                    if (versionRequirement.includes("||")) {
-
-                        // Split by "||" and check only the last range
-                        const ranges = versionRequirement.split("||").map(range => range.trim());
-                        const lastRange = ranges.at(-1);
-
-                        // Check if the last range allows version 9 or higher
-                        isDefineConfigExported = ESLINT_9_PLUS_REGEX.test(lastRange);
-                    } else {
-
-                        // Simple version check for non-complex ranges
-                        isDefineConfigExported = ESLINT_9_PLUS_REGEX.test(versionRequirement);
-                    }
+                    // Check if the version requirement allows for ESLint 9.22.0+
+                    isDefineConfigExported = semverSatisfies("9.22.0", versionRequirement);
 
                     // eslint is in the peer dependencies => overwrite eslint version
                     this.result.devDependencies[0] = peers[eslintIndex];

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -268,10 +268,6 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
                     peers.splice(eslintIndex, 1);
                     this.result.devDependencies.push(...peers);
                 }
-
-                if (isDefineConfigExported) {
-                    importContent += "import { defineConfig } from \"eslint/config\";\n";
-                }
             }
 
             if (config.type === "flat" || config.type === void 0) {
@@ -286,6 +282,10 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
             }
         } else {
             isDefineConfigExported = true;
+        }
+
+        if (isDefineConfigExported) {
+            importContent += "import { defineConfig } from \"eslint/config\";\n";
         }
 
         if (needCompatHelper) {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -154,7 +154,8 @@ export class ConfigGenerator {
             : this.answers.config;
         const extensions = `**/*.{${getExtensions(this.answers)}}`;
 
-        let importContent = "import { defineConfig } from \"eslint/config\";\n";
+        let isDefineConfigExported = false;
+        let importContent = "";
         const helperContent = `import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
@@ -232,11 +233,28 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
 
                     this.result.devDependencies.push(...peers);
                 } else {
+                    const versionMatch = peers[eslintIndex].match(/eslint@([\^~]?)(.+)/u);
+                    const versionPrefix = versionMatch[1]; // Will be "^", "~", or empty string
+                    const eslintVersion = versionMatch[2];
 
+
+                    // Now if version prefix is "^" & eslint version is greater than 9, we can use defineConfig
+                    if (versionPrefix === "^" && parseFloat(eslintVersion) >= 9) {
+                        isDefineConfigExported = true;
+                    }
+
+                    // If version prefix is empty string or "~", we need to check if the version is greater than 9.22.0 which is the first version that supports defineConfig
+                    if ((versionPrefix === "~" || versionPrefix.length === 0) && parseFloat(eslintVersion) >= 9.22) {
+                        isDefineConfigExported = true;
+                    }
                     // eslint is in the peer dependencies => overwrite eslint version
                     this.result.devDependencies[0] = peers[eslintIndex];
                     peers.splice(eslintIndex, 1);
                     this.result.devDependencies.push(...peers);
+                }
+
+                if (isDefineConfigExported) {
+                    importContent += "import { defineConfig } from \"eslint/config\";\n";
                 }
             }
 
@@ -259,10 +277,11 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
         const lintFilesConfig = `  { files: ["${extensions}"] },\n`;
 
         exportContent = `${lintFilesConfig}${exportContent}`;
+        exportContent = `[\n${exportContent || "  {}\n"}]`;
 
         this.result.configContent = `${importContent}
 ${needCompatHelper ? helperContent : ""}
-export default defineConfig([\n${exportContent || "  {}\n"}]);`; // defaults to `[{}]` to avoid empty config warning
+export default ${isDefineConfigExported ? `defineConfig(${exportContent})` : exportContent};`; // defaults to `[{}]` to avoid empty config warning
     }
 
     /**
@@ -316,4 +335,5 @@ export default defineConfig([\n${exportContent || "  {}\n"}]);`; // defaults to 
             log.warn("You will need to install the dependencies yourself.");
         }
     }
+
 }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -21,6 +21,17 @@ import * as log from "./utils/logging.js";
 //-----------------------------------------------------------------------------
 
 /**
+ * Regular expression to check if a version requirement allows ESLint 9.22.0 or higher.
+ * Matches:
+ * - "^9" (any ^9.x.x version)
+ * - ">=9" (version 9.0.0 or higher)
+ * - "~9.22" or higher minor versions (9.22.x and above)
+ * - "9.22" or higher versions without prefix
+ * - Correctly handles full semver notation (e.g., 9.22.0, ~9.22.0)
+ */
+const ESLINT_9_PLUS_REGEX = /\^9|>=\s*9|(?:~|^)9\.(2[2-9]|[3-9]\d|\d{3,})/u;
+
+/**
  * Get the file extensions to lint based on the user's answers.
  * @param {Object} answers The answers provided by the user.
  * @returns {string[]} The file extensions to lint.
@@ -233,20 +244,23 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
 
                     this.result.devDependencies.push(...peers);
                 } else {
-                    const versionMatch = peers[eslintIndex].match(/eslint@([\^~]?)(.+)/u);
-                    const versionPrefix = versionMatch[1]; // Will be "^", "~", or empty string
-                    const eslintVersion = versionMatch[2];
-
-
-                    // Now if version prefix is "^" & eslint version is greater than 9, we can use defineConfig
-                    if (versionPrefix === "^" && parseFloat(eslintVersion) >= 9) {
-                        isDefineConfigExported = true;
+                    const versionMatch = peers[eslintIndex].match(/eslint@(.+)/u);
+                    console.log("🚀 ~ ConfigGenerator ~ calc ~ versionMatch:", versionMatch)
+                    const versionRequirement = versionMatch[1]; // Complete version requirement string
+                    
+                    // Check if the version requirement allows for ESLint 9+                    
+                    // Handle complex version ranges with "||"
+                    if (versionRequirement.includes("||")) {
+                        // Split by "||" and check only the last range
+                        const ranges = versionRequirement.split("||").map(range => range.trim());
+                        const lastRange = ranges[ranges.length - 1];
+                        // Check if the last range allows version 9 or higher
+                        isDefineConfigExported = ESLINT_9_PLUS_REGEX.test(lastRange);
+                    } else {
+                        // Simple version check for non-complex ranges
+                        isDefineConfigExported = ESLINT_9_PLUS_REGEX.test(versionRequirement);
                     }
 
-                    // If version prefix is empty string or "~", we need to check if the version is greater than 9.22.0 which is the first version that supports defineConfig
-                    if ((versionPrefix === "~" || versionPrefix.length === 0) && parseFloat(eslintVersion) >= 9.22) {
-                        isDefineConfigExported = true;
-                    }
                     // eslint is in the peer dependencies => overwrite eslint version
                     this.result.devDependencies[0] = peers[eslintIndex];
                     peers.splice(eslintIndex, 1);

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -246,16 +246,19 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
                 } else {
                     const versionMatch = peers[eslintIndex].match(/eslint@(.+)/u);
                     const versionRequirement = versionMatch[1]; // Complete version requirement string
-                    
-                    // Check if the version requirement allows for ESLint 9+                    
+
+                    // Check if the version requirement allows for ESLint 9+
                     // Handle complex version ranges with "||"
                     if (versionRequirement.includes("||")) {
+
                         // Split by "||" and check only the last range
                         const ranges = versionRequirement.split("||").map(range => range.trim());
-                        const lastRange = ranges[ranges.length - 1];
+                        const lastRange = ranges.at(-1);
+
                         // Check if the last range allows version 9 or higher
                         isDefineConfigExported = ESLINT_9_PLUS_REGEX.test(lastRange);
                     } else {
+
                         // Simple version check for non-complex ranges
                         isDefineConfigExported = ESLINT_9_PLUS_REGEX.test(versionRequirement);
                     }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -165,7 +165,7 @@ export class ConfigGenerator {
             : this.answers.config;
         const extensions = `**/*.{${getExtensions(this.answers)}}`;
 
-        let isDefineConfigExported = false;
+        let isDefineConfigExported = true;
         let importContent = "";
         const helperContent = `import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -256,11 +256,11 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
                         const lastRange = ranges.at(-1);
 
                         // Check if the last range allows version 9 or higher
-                        isDefineConfigExported = ESLINT_9_PLUS_REGEX.test(lastRange);
+                        isDefineConfigExported = !ESLINT_9_PLUS_REGEX.test(lastRange);
                     } else {
 
                         // Simple version check for non-complex ranges
-                        isDefineConfigExported = ESLINT_9_PLUS_REGEX.test(versionRequirement);
+                        isDefineConfigExported = !ESLINT_9_PLUS_REGEX.test(versionRequirement);
                     }
 
                     // eslint is in the peer dependencies => overwrite eslint version

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -309,7 +309,7 @@ export class ConfigGenerator {
         }
         this.result.configContent = `${importContent}
 ${needCompatHelper ? helperContent : ""}
-export default ${`defineConfig(${exportContent})`};`;
+export default defineConfig([\n${exportContent || "  {}\n"}]);`; // defaults to `[{}]` to avoid empty config warning
     }
 
     /**
@@ -347,5 +347,4 @@ export default ${`defineConfig(${exportContent})`};`;
             log.warn("You will need to install the dependencies yourself.");
         }
     }
-
 }

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -286,6 +286,9 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
 
         if (isDefineConfigExported) {
             importContent += "import { defineConfig } from \"eslint/config\";\n";
+        } else {
+            this.result.devDependencies.push("@eslint/config-helpers");
+            importContent += "import { defineConfig } from \"@eslint/config-helpers\";\n";
         }
 
         if (needCompatHelper) {
@@ -295,11 +298,11 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
         const lintFilesConfig = `  { files: ["${extensions}"] },\n`;
 
         exportContent = `${lintFilesConfig}${exportContent}`;
-        exportContent = `[\n${exportContent || "  {}\n"}]`;
+        exportContent = `[\n${exportContent || "  {}\n"}]`; // defaults to `[{}]` to avoid empty config warning
 
         this.result.configContent = `${importContent}
 ${needCompatHelper ? helperContent : ""}
-export default ${isDefineConfigExported ? `defineConfig(${exportContent})` : exportContent};`; // defaults to `[{}]` to avoid empty config warning
+export default ${`defineConfig(${exportContent})`};`;
     }
 
     /**

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -165,7 +165,7 @@ export class ConfigGenerator {
             : this.answers.config;
         const extensions = `**/*.{${getExtensions(this.answers)}}`;
 
-        let isDefineConfigExported = true;
+        let isDefineConfigExported = false;
         let importContent = "";
         const helperContent = `import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -256,11 +256,11 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
                         const lastRange = ranges.at(-1);
 
                         // Check if the last range allows version 9 or higher
-                        isDefineConfigExported = !ESLINT_9_PLUS_REGEX.test(lastRange);
+                        isDefineConfigExported = ESLINT_9_PLUS_REGEX.test(lastRange);
                     } else {
 
                         // Simple version check for non-complex ranges
-                        isDefineConfigExported = !ESLINT_9_PLUS_REGEX.test(versionRequirement);
+                        isDefineConfigExported = ESLINT_9_PLUS_REGEX.test(versionRequirement);
                     }
 
                     // eslint is in the peer dependencies => overwrite eslint version
@@ -284,6 +284,8 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
 
                 exportContent += `  compat.extends("${shorthandName}"),\n`;
             }
+        } else {
+            isDefineConfigExported = true;
         }
 
         if (needCompatHelper) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     },
     "dependencies": {
         "cross-spawn": "^7.0.2",
-        "enquirer": "^2.3.5"
+        "enquirer": "^2.3.5",
+        "semver": "^7.7.1"
     },
     "devDependencies": {
         "@vitest/coverage-v8": "^1.3.1",

--- a/tests/__snapshots__/config@eslint-config-airbnb
+++ b/tests/__snapshots__/config@eslint-config-airbnb
@@ -1,5 +1,6 @@
 {
-  "configContent": "
+  "configContent": "import { defineConfig } from "eslint/config";
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
@@ -10,10 +11,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   compat.extends("airbnb"),
-];",
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^7.32.0 || ^8.2.0",

--- a/tests/__snapshots__/config@eslint-config-airbnb
+++ b/tests/__snapshots__/config@eslint-config-airbnb
@@ -11,8 +11,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-export default defineConfig(  compat.extends("airbnb"),
-);",
+export default defineConfig([
+  compat.extends("airbnb"),
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^7.32.0 || ^8.2.0",

--- a/tests/__snapshots__/config@eslint-config-airbnb
+++ b/tests/__snapshots__/config@eslint-config-airbnb
@@ -1,6 +1,5 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-
+  "configContent": "
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
@@ -11,10 +10,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   compat.extends("airbnb"),
-]);",
+];",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^7.32.0 || ^8.2.0",

--- a/tests/__snapshots__/config@eslint-config-airbnb-base
+++ b/tests/__snapshots__/config@eslint-config-airbnb-base
@@ -1,6 +1,5 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-
+  "configContent": "
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
@@ -11,10 +10,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   compat.extends("airbnb-base"),
-]);",
+];",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^7.32.0 || ^8.2.0",

--- a/tests/__snapshots__/config@eslint-config-airbnb-base
+++ b/tests/__snapshots__/config@eslint-config-airbnb-base
@@ -1,5 +1,6 @@
 {
-  "configContent": "
+  "configContent": "import { defineConfig } from "eslint/config";
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
@@ -10,10 +11,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   compat.extends("airbnb-base"),
-];",
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^7.32.0 || ^8.2.0",

--- a/tests/__snapshots__/config@eslint-config-airbnb-base
+++ b/tests/__snapshots__/config@eslint-config-airbnb-base
@@ -11,8 +11,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-export default defineConfig(  compat.extends("airbnb-base"),
-);",
+export default defineConfig([
+  compat.extends("airbnb-base"),
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^7.32.0 || ^8.2.0",

--- a/tests/__snapshots__/config@eslint-config-standard
+++ b/tests/__snapshots__/config@eslint-config-standard
@@ -11,8 +11,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-export default defineConfig(  compat.extends("standard"),
-);",
+export default defineConfig([
+  compat.extends("standard"),
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard
+++ b/tests/__snapshots__/config@eslint-config-standard
@@ -1,5 +1,6 @@
 {
-  "configContent": "
+  "configContent": "import { defineConfig } from "eslint/config";
+
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
@@ -10,10 +11,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   compat.extends("standard"),
-];",
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard
+++ b/tests/__snapshots__/config@eslint-config-standard
@@ -1,6 +1,5 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-
+  "configContent": "
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { FlatCompat } from "@eslint/eslintrc";
@@ -11,10 +10,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   compat.extends("standard"),
-]);",
+];",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard-flat
+++ b/tests/__snapshots__/config@eslint-config-standard-flat
@@ -1,11 +1,12 @@
 {
-  "configContent": "import config from "eslint-config-standard";
+  "configContent": "import { defineConfig } from "eslint/config";
+import config from "eslint-config-standard";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   config,
-];",
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard-flat
+++ b/tests/__snapshots__/config@eslint-config-standard-flat
@@ -1,12 +1,11 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import config from "eslint-config-standard";
+  "configContent": "import config from "eslint-config-standard";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   config,
-]);",
+];",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard-flat
+++ b/tests/__snapshots__/config@eslint-config-standard-flat
@@ -3,8 +3,9 @@
 import { defineConfig } from "@eslint/config-helpers";
 
 
-export default defineConfig(  config,
-);",
+export default defineConfig([
+  config,
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard-flat2
+++ b/tests/__snapshots__/config@eslint-config-standard-flat2
@@ -1,11 +1,12 @@
 {
-  "configContent": "import config from "eslint-config-standard";
+  "configContent": "import { defineConfig } from "eslint/config";
+import config from "eslint-config-standard";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   config,
-];",
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard-flat2
+++ b/tests/__snapshots__/config@eslint-config-standard-flat2
@@ -1,12 +1,11 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import config from "eslint-config-standard";
+  "configContent": "import config from "eslint-config-standard";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   config,
-]);",
+];",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard-flat2
+++ b/tests/__snapshots__/config@eslint-config-standard-flat2
@@ -3,8 +3,9 @@
 import { defineConfig } from "@eslint/config-helpers";
 
 
-export default defineConfig(  config,
-);",
+export default defineConfig([
+  config,
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-xo
+++ b/tests/__snapshots__/config@eslint-config-xo
@@ -1,6 +1,6 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import config from "eslint-config-xo";
+  "configContent": "import config from "eslint-config-xo";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/config@eslint-config-xo
+++ b/tests/__snapshots__/config@eslint-config-xo
@@ -3,8 +3,9 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  config,
-);",
+export default defineConfig([
+  config,
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@>=9.8.0",

--- a/tests/__snapshots__/config@eslint-config-xo
+++ b/tests/__snapshots__/config@eslint-config-xo
@@ -1,11 +1,12 @@
 {
-  "configContent": "import config from "eslint-config-xo";
+  "configContent": "import { defineConfig } from "eslint/config";
+import config from "eslint-config-xo";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   config,
-];",
+]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@>=9.8.0",

--- a/tests/__snapshots__/config@eslint-config-xo
+++ b/tests/__snapshots__/config@eslint-config-xo
@@ -1,12 +1,11 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import config from "eslint-config-xo";
+  "configContent": "import config from "eslint-config-xo";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   config,
-]);",
+];",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@>=9.8.0",

--- a/tests/__snapshots__/empty
+++ b/tests/__snapshots__/empty
@@ -2,7 +2,9 @@
   "configContent": "import { defineConfig } from "eslint/config";
 
 
-export default defineConfig();",
+export default defineConfig([
+  {}
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/empty
+++ b/tests/__snapshots__/empty
@@ -1,10 +1,9 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
+  "configContent": "
 
-
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/empty
+++ b/tests/__snapshots__/empty
@@ -1,9 +1,9 @@
 {
   "configContent": "
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/empty
+++ b/tests/__snapshots__/empty
@@ -1,5 +1,6 @@
 {
-  "configContent": "
+  "configContent": "import { defineConfig } from "eslint/config";
+
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },

--- a/tests/__snapshots__/esm-css-problems
+++ b/tests/__snapshots__/esm-css-problems
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.css"], plugins: { css }, language: "css/css", extends: ["css/recommended"] },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-css-syntax
+++ b/tests/__snapshots__/esm-css-syntax
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.css"], plugins: { css }, language: "css/css" },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-javascript-json-problems
+++ b/tests/__snapshots__/esm-javascript-json-problems
@@ -5,10 +5,11 @@ import json from "@eslint/json";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: globals.node } },
   { files: ["**/*.json"], plugins: { json }, language: "json/json", extends: ["json/recommended"] },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-json-problems
+++ b/tests/__snapshots__/esm-json-problems
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json"], plugins: { json }, language: "json/json", extends: ["json/recommended"] },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-json-syntax
+++ b/tests/__snapshots__/esm-json-syntax
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json"], plugins: { json }, language: "json/json" },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-json5-problems
+++ b/tests/__snapshots__/esm-json5-problems
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json5"], plugins: { json }, language: "json/json5", extends: ["json/recommended"] },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-json5-syntax
+++ b/tests/__snapshots__/esm-json5-syntax
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json5"], plugins: { json }, language: "json/json5" },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-jsonc-problems
+++ b/tests/__snapshots__/esm-jsonc-problems
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.jsonc"], plugins: { json }, language: "json/jsonc", extends: ["json/recommended"] },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-jsonc-syntax
+++ b/tests/__snapshots__/esm-jsonc-syntax
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.jsonc"], plugins: { json }, language: "json/jsonc" },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-markdown-commonmark-problems
+++ b/tests/__snapshots__/esm-markdown-commonmark-problems
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/commonmark", extends: ["markdown/recommended"] },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-markdown-commonmark-syntax
+++ b/tests/__snapshots__/esm-markdown-commonmark-syntax
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/commonmark" },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-markdown-gfm-problems
+++ b/tests/__snapshots__/esm-markdown-gfm-problems
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/gfm", extends: ["markdown/recommended"] },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-markdown-gfm-syntax
+++ b/tests/__snapshots__/esm-markdown-gfm-syntax
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
+export default defineConfig([
+  { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/gfm" },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-none-javascript
+++ b/tests/__snapshots__/problems-commonjs-none-javascript
@@ -1,15 +1,14 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-none-javascript
+++ b/tests/__snapshots__/problems-commonjs-none-javascript
@@ -4,10 +4,11 @@ import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-none-javascript
+++ b/tests/__snapshots__/problems-commonjs-none-javascript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-commonjs-none-javascript
+++ b/tests/__snapshots__/problems-commonjs-none-javascript
@@ -3,12 +3,12 @@
 import js from "@eslint/js";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -4,13 +4,13 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -1,17 +1,16 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -5,11 +5,12 @@ import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-react-javascript
+++ b/tests/__snapshots__/problems-commonjs-react-javascript
@@ -1,17 +1,16 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-react-javascript
+++ b/tests/__snapshots__/problems-commonjs-react-javascript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-commonjs-react-javascript
+++ b/tests/__snapshots__/problems-commonjs-react-javascript
@@ -4,13 +4,13 @@ import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-react-javascript
+++ b/tests/__snapshots__/problems-commonjs-react-javascript
@@ -5,11 +5,12 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -3,6 +3,7 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -1,19 +1,18 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -6,12 +6,13 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -5,14 +5,14 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-vue-javascript
+++ b/tests/__snapshots__/problems-commonjs-vue-javascript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-commonjs-vue-javascript
+++ b/tests/__snapshots__/problems-commonjs-vue-javascript
@@ -1,17 +1,16 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   pluginVue.configs["flat/essential"],
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-vue-javascript
+++ b/tests/__snapshots__/problems-commonjs-vue-javascript
@@ -5,11 +5,12 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-vue-javascript
+++ b/tests/__snapshots__/problems-commonjs-vue-javascript
@@ -4,13 +4,13 @@ import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   pluginVue.configs["flat/essential"],
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -1,12 +1,11 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
@@ -14,7 +13,7 @@ export default defineConfig([
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -3,6 +3,7 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -5,7 +5,7 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
@@ -13,7 +13,7 @@ export default [
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -6,13 +6,14 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-none-javascript
+++ b/tests/__snapshots__/problems-esm-none-javascript
@@ -3,11 +3,11 @@
 import js from "@eslint/js";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-none-javascript
+++ b/tests/__snapshots__/problems-esm-none-javascript
@@ -1,14 +1,13 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-none-javascript
+++ b/tests/__snapshots__/problems-esm-none-javascript
@@ -4,9 +4,10 @@ import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-none-javascript
+++ b/tests/__snapshots__/problems-esm-none-javascript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -4,12 +4,12 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -5,10 +5,11 @@ import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -1,16 +1,15 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-react-javascript
+++ b/tests/__snapshots__/problems-esm-react-javascript
@@ -4,12 +4,12 @@ import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-react-javascript
+++ b/tests/__snapshots__/problems-esm-react-javascript
@@ -5,10 +5,11 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-react-javascript
+++ b/tests/__snapshots__/problems-esm-react-javascript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-esm-react-javascript
+++ b/tests/__snapshots__/problems-esm-react-javascript
@@ -1,16 +1,15 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -3,6 +3,7 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -1,18 +1,17 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -5,13 +5,13 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -6,11 +6,12 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-vue-javascript
+++ b/tests/__snapshots__/problems-esm-vue-javascript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-esm-vue-javascript
+++ b/tests/__snapshots__/problems-esm-vue-javascript
@@ -4,12 +4,12 @@ import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   pluginVue.configs["flat/essential"],
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-vue-javascript
+++ b/tests/__snapshots__/problems-esm-vue-javascript
@@ -1,16 +1,15 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   pluginVue.configs["flat/essential"],
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-vue-javascript
+++ b/tests/__snapshots__/problems-esm-vue-javascript
@@ -5,10 +5,11 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -1,19 +1,18 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -3,6 +3,7 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -5,14 +5,14 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -6,12 +6,13 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-none-javascript
+++ b/tests/__snapshots__/problems-script-none-javascript
@@ -4,10 +4,11 @@ import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-none-javascript
+++ b/tests/__snapshots__/problems-script-none-javascript
@@ -1,15 +1,14 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-none-javascript
+++ b/tests/__snapshots__/problems-script-none-javascript
@@ -3,12 +3,12 @@
 import js from "@eslint/js";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-none-javascript
+++ b/tests/__snapshots__/problems-script-none-javascript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -5,11 +5,12 @@ import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -1,17 +1,16 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -4,13 +4,13 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-react-javascript
+++ b/tests/__snapshots__/problems-script-react-javascript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-script-react-javascript
+++ b/tests/__snapshots__/problems-script-react-javascript
@@ -1,17 +1,16 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-react-javascript
+++ b/tests/__snapshots__/problems-script-react-javascript
@@ -5,11 +5,12 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-react-javascript
+++ b/tests/__snapshots__/problems-script-react-javascript
@@ -4,13 +4,13 @@ import js from "@eslint/js";
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -1,19 +1,18 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -3,6 +3,7 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -5,14 +5,14 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -6,12 +6,13 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-vue-javascript
+++ b/tests/__snapshots__/problems-script-vue-javascript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-script-vue-javascript
+++ b/tests/__snapshots__/problems-script-vue-javascript
@@ -5,11 +5,12 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-vue-javascript
+++ b/tests/__snapshots__/problems-script-vue-javascript
@@ -4,13 +4,13 @@ import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   pluginVue.configs["flat/essential"],
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-vue-javascript
+++ b/tests/__snapshots__/problems-script-vue-javascript
@@ -1,17 +1,16 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   pluginVue.configs["flat/essential"],
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -3,6 +3,7 @@
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -5,7 +5,7 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
@@ -13,7 +13,7 @@ export default [
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -6,13 +6,14 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -1,12 +1,11 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
@@ -14,7 +13,7 @@ export default defineConfig([
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-none-javascript
+++ b/tests/__snapshots__/syntax-commonjs-none-javascript
@@ -1,5 +1,6 @@
 {
   "configContent": "import globals from "globals";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-commonjs-none-javascript
+++ b/tests/__snapshots__/syntax-commonjs-none-javascript
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-none-javascript
+++ b/tests/__snapshots__/syntax-commonjs-none-javascript
@@ -2,11 +2,11 @@
   "configContent": "import globals from "globals";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-none-javascript
+++ b/tests/__snapshots__/syntax-commonjs-none-javascript
@@ -1,13 +1,12 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-none-typescript
+++ b/tests/__snapshots__/syntax-commonjs-none-typescript
@@ -4,10 +4,11 @@ import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-none-typescript
+++ b/tests/__snapshots__/syntax-commonjs-none-typescript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-commonjs-none-typescript
+++ b/tests/__snapshots__/syntax-commonjs-none-typescript
@@ -1,15 +1,14 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-none-typescript
+++ b/tests/__snapshots__/syntax-commonjs-none-typescript
@@ -3,12 +3,12 @@
 import tseslint from "typescript-eslint";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-javascript
+++ b/tests/__snapshots__/syntax-commonjs-react-javascript
@@ -3,12 +3,12 @@
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-javascript
+++ b/tests/__snapshots__/syntax-commonjs-react-javascript
@@ -4,10 +4,11 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-javascript
+++ b/tests/__snapshots__/syntax-commonjs-react-javascript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-commonjs-react-javascript
+++ b/tests/__snapshots__/syntax-commonjs-react-javascript
@@ -1,15 +1,14 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-typescript
+++ b/tests/__snapshots__/syntax-commonjs-react-typescript
@@ -1,17 +1,16 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-typescript
+++ b/tests/__snapshots__/syntax-commonjs-react-typescript
@@ -4,13 +4,13 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-typescript
+++ b/tests/__snapshots__/syntax-commonjs-react-typescript
@@ -5,11 +5,12 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-typescript
+++ b/tests/__snapshots__/syntax-commonjs-react-typescript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-commonjs-vue-javascript
+++ b/tests/__snapshots__/syntax-commonjs-vue-javascript
@@ -3,12 +3,12 @@
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-vue-javascript
+++ b/tests/__snapshots__/syntax-commonjs-vue-javascript
@@ -1,15 +1,14 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-vue-javascript
+++ b/tests/__snapshots__/syntax-commonjs-vue-javascript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-commonjs-vue-javascript
+++ b/tests/__snapshots__/syntax-commonjs-vue-javascript
@@ -4,10 +4,11 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-vue-typescript
+++ b/tests/__snapshots__/syntax-commonjs-vue-typescript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-commonjs-vue-typescript
+++ b/tests/__snapshots__/syntax-commonjs-vue-typescript
@@ -4,14 +4,14 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-vue-typescript
+++ b/tests/__snapshots__/syntax-commonjs-vue-typescript
@@ -1,18 +1,17 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-vue-typescript
+++ b/tests/__snapshots__/syntax-commonjs-vue-typescript
@@ -5,12 +5,13 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-none-javascript
+++ b/tests/__snapshots__/syntax-esm-none-javascript
@@ -1,5 +1,6 @@
 {
   "configContent": "import globals from "globals";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-esm-none-javascript
+++ b/tests/__snapshots__/syntax-esm-none-javascript
@@ -3,8 +3,9 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-);",
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-none-javascript
+++ b/tests/__snapshots__/syntax-esm-none-javascript
@@ -2,10 +2,10 @@
   "configContent": "import globals from "globals";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-none-javascript
+++ b/tests/__snapshots__/syntax-esm-none-javascript
@@ -1,12 +1,11 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-none-typescript
+++ b/tests/__snapshots__/syntax-esm-none-typescript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-esm-none-typescript
+++ b/tests/__snapshots__/syntax-esm-none-typescript
@@ -1,14 +1,13 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-none-typescript
+++ b/tests/__snapshots__/syntax-esm-none-typescript
@@ -4,9 +4,10 @@ import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-none-typescript
+++ b/tests/__snapshots__/syntax-esm-none-typescript
@@ -3,11 +3,11 @@
 import tseslint from "typescript-eslint";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-javascript
+++ b/tests/__snapshots__/syntax-esm-react-javascript
@@ -4,9 +4,10 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-javascript
+++ b/tests/__snapshots__/syntax-esm-react-javascript
@@ -3,11 +3,11 @@
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-javascript
+++ b/tests/__snapshots__/syntax-esm-react-javascript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-esm-react-javascript
+++ b/tests/__snapshots__/syntax-esm-react-javascript
@@ -1,14 +1,13 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-typescript
+++ b/tests/__snapshots__/syntax-esm-react-typescript
@@ -1,16 +1,15 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-typescript
+++ b/tests/__snapshots__/syntax-esm-react-typescript
@@ -5,10 +5,11 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-typescript
+++ b/tests/__snapshots__/syntax-esm-react-typescript
@@ -4,12 +4,12 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-typescript
+++ b/tests/__snapshots__/syntax-esm-react-typescript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-esm-vue-javascript
+++ b/tests/__snapshots__/syntax-esm-vue-javascript
@@ -1,14 +1,13 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-vue-javascript
+++ b/tests/__snapshots__/syntax-esm-vue-javascript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-esm-vue-javascript
+++ b/tests/__snapshots__/syntax-esm-vue-javascript
@@ -4,9 +4,10 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-vue-javascript
+++ b/tests/__snapshots__/syntax-esm-vue-javascript
@@ -3,11 +3,11 @@
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-vue-typescript
+++ b/tests/__snapshots__/syntax-esm-vue-typescript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-esm-vue-typescript
+++ b/tests/__snapshots__/syntax-esm-vue-typescript
@@ -4,13 +4,13 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-vue-typescript
+++ b/tests/__snapshots__/syntax-esm-vue-typescript
@@ -5,11 +5,12 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+export default defineConfig([
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-vue-typescript
+++ b/tests/__snapshots__/syntax-esm-vue-typescript
@@ -1,17 +1,16 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-none-javascript
+++ b/tests/__snapshots__/syntax-script-none-javascript
@@ -1,5 +1,6 @@
 {
   "configContent": "import globals from "globals";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-script-none-javascript
+++ b/tests/__snapshots__/syntax-script-none-javascript
@@ -1,13 +1,12 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-none-javascript
+++ b/tests/__snapshots__/syntax-script-none-javascript
@@ -2,11 +2,11 @@
   "configContent": "import globals from "globals";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-none-javascript
+++ b/tests/__snapshots__/syntax-script-none-javascript
@@ -3,9 +3,10 @@
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-none-typescript
+++ b/tests/__snapshots__/syntax-script-none-typescript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-script-none-typescript
+++ b/tests/__snapshots__/syntax-script-none-typescript
@@ -4,10 +4,11 @@ import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-none-typescript
+++ b/tests/__snapshots__/syntax-script-none-typescript
@@ -3,12 +3,12 @@
 import tseslint from "typescript-eslint";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-none-typescript
+++ b/tests/__snapshots__/syntax-script-none-typescript
@@ -1,15 +1,14 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-react-javascript
+++ b/tests/__snapshots__/syntax-script-react-javascript
@@ -3,12 +3,12 @@
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-react-javascript
+++ b/tests/__snapshots__/syntax-script-react-javascript
@@ -1,15 +1,14 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,jsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-react-javascript
+++ b/tests/__snapshots__/syntax-script-react-javascript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-script-react-javascript
+++ b/tests/__snapshots__/syntax-script-react-javascript
@@ -4,10 +4,11 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-react-typescript
+++ b/tests/__snapshots__/syntax-script-react-typescript
@@ -5,11 +5,12 @@ import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-react-typescript
+++ b/tests/__snapshots__/syntax-script-react-typescript
@@ -1,17 +1,16 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-react-typescript
+++ b/tests/__snapshots__/syntax-script-react-typescript
@@ -4,13 +4,13 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-react-typescript
+++ b/tests/__snapshots__/syntax-script-react-typescript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-script-vue-javascript
+++ b/tests/__snapshots__/syntax-script-vue-javascript
@@ -1,15 +1,14 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-vue-javascript
+++ b/tests/__snapshots__/syntax-script-vue-javascript
@@ -1,6 +1,7 @@
 {
   "configContent": "import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-script-vue-javascript
+++ b/tests/__snapshots__/syntax-script-vue-javascript
@@ -4,10 +4,11 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-vue-javascript
+++ b/tests/__snapshots__/syntax-script-vue-javascript
@@ -3,12 +3,12 @@
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-vue-typescript
+++ b/tests/__snapshots__/syntax-script-vue-typescript
@@ -4,14 +4,14 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default [
+export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-];",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-vue-typescript
+++ b/tests/__snapshots__/syntax-script-vue-typescript
@@ -1,18 +1,17 @@
 {
-  "configContent": "import { defineConfig } from "eslint/config";
-import globals from "globals";
+  "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 
 
-export default defineConfig([
+export default [
   { files: ["**/*.{js,mjs,cjs,ts,vue}"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+];",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-vue-typescript
+++ b/tests/__snapshots__/syntax-script-vue-typescript
@@ -2,6 +2,7 @@
   "configContent": "import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
+import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([

--- a/tests/__snapshots__/syntax-script-vue-typescript
+++ b/tests/__snapshots__/syntax-script-vue-typescript
@@ -5,12 +5,13 @@ import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 
-export default defineConfig(  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
+export default defineConfig([
+  { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-);",
+]);",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",


### PR DESCRIPTION
Fix https://github.com/eslint/create-config/issues/160


-  Added a regular expression to check if a version requirement allows ESLint 9.22.0 or higher.
- Conditional Import: Introduced logic to import defineConfig based on the ESLint version requirement conditionally.
- Version Check: Implemented checks for complex and simple version requirements to ensure compatibility with ESLint 9+.