### PR TITLE
fix: use correct import path for semver

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -12,7 +12,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import enquirer from "enquirer";
-import semverSatisfies from "semver/functions/satisfies";
+import semverSatisfies from "semver/functions/satisfies.js";
 import { isPackageTypeModule, installSyncSaveDev, fetchPeerDependencies, findPackageJson } from "./utils/npm-utils.js";
 import { getShorthandName } from "./utils/naming.js";
 import * as log from "./utils/logging.js";


### PR DESCRIPTION
This PR corrects the import path for `semver`, because it fails on `1.8.0` with:
`Error [ERR_MODULE_NOT_FOUND]: Cannot find module '<projectRoot>/node_modules/semver/functions/satisfies' imported from <projectRoot>/lib/config-generator.js`