### PR TITLE
ci: run tests in Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [23.x, 22.x, 21.x, 20.x, 18.x, "18.18.0"]
+        node: [24.x, 22.x, 20.x, 18.x, "18.18.0"]
         include:
         - os: windows-latest
           node: "lts/*"


### PR DESCRIPTION
Hello,

This PR is a follow-up to https://github.com/eslint/eslint/pull/19702.

I've updated the GitHub Actions CI workflow to include Node.js 24 in the test matrix and to remove the odd-numbered version, 21 and 23.