### PR TITLE
fix: semver calculations for `defineConfig` import

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -12,7 +12,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import enquirer from "enquirer";
-import semverGreaterThanRange from "semver/ranges/gtr";
+import semverGreaterThanRange from "semver/ranges/gtr.js";
 import { isPackageTypeModule, installSyncSaveDev, fetchPeerDependencies, findPackageJson } from "./utils/npm-utils.js";
 import { getShorthandName } from "./utils/naming.js";
 import * as log from "./utils/logging.js";

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -12,7 +12,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import enquirer from "enquirer";
-import semverSatisfies from "semver/functions/satisfies.js";
+import semverGreaterThanRange from "semver/ranges/gtr";
 import { isPackageTypeModule, installSyncSaveDev, fetchPeerDependencies, findPackageJson } from "./utils/npm-utils.js";
 import { getShorthandName } from "./utils/naming.js";
 import * as log from "./utils/logging.js";
@@ -251,7 +251,7 @@ export class ConfigGenerator {
                     const versionRequirement = versionMatch[1]; // Complete version requirement string
 
                     // Check if the version requirement allows for ESLint 9.22.0+
-                    isDefineConfigExported = semverSatisfies("9.22.0", versionRequirement);
+                    isDefineConfigExported = !semverGreaterThanRange("9.22.0", versionRequirement);
 
                     // eslint is in the peer dependencies => overwrite eslint version
                     this.result.devDependencies[0] = peers[eslintIndex];

--- a/tests/__snapshots__/config@eslint-config-xo
+++ b/tests/__snapshots__/config@eslint-config-xo
@@ -8,7 +8,7 @@ export default defineConfig([
 ]);",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
-    "eslint@>=9.8.0",
+    "eslint@>=9.25.0",
     "eslint-config-xo",
   ],
   "installFlags": [


### PR DESCRIPTION
To determine whether the version of ESLint required by a shareable config exports `defineConfig()`, `@eslint/create-config` currently uses `semver.satisfies("9.22.0", range)` check.

However, the latest `eslint-config-xo` requires `"eslint": "^9.25.1"`, so ESLint v9.22.0 doesn't satisfy the requirements, and thus the check returns `false` and `@eslint/create-config` mistakenly imports `defineConfig()` from `@eslint/config-helpers`, as shown by the test failure on https://github.com/eslint/create-config/pull/167.

What `@eslint/create-config` should check is, I think, whether any of >= 9.22.0 is in the range, so I replaced the check with `!semver.gtr("9.22.0", range)`.