### PR TITLE
fix: ensure posix-compliant newline at end of generated configs

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -286,7 +286,7 @@ export class ConfigGenerator {
         }
         this.result.configContent = `${importContent}
 ${needCompatHelper ? helperContent : ""}
-export default defineConfig([\n${exportContent || "  {}\n"}]);`; // defaults to `[{}]` to avoid empty config warning
+export default defineConfig([\n${exportContent || "  {}\n"}]);\n`; // defaults to `[{}]` to avoid empty config warning
     }
 
     /**

--- a/tests/__snapshots__/config@eslint-config-airbnb
+++ b/tests/__snapshots__/config@eslint-config-airbnb
@@ -13,7 +13,8 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
 
 export default defineConfig([
   compat.extends("airbnb"),
-]);",
+]);
+",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^7.32.0 || ^8.2.0",

--- a/tests/__snapshots__/config@eslint-config-airbnb-base
+++ b/tests/__snapshots__/config@eslint-config-airbnb-base
@@ -13,7 +13,8 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
 
 export default defineConfig([
   compat.extends("airbnb-base"),
-]);",
+]);
+",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^7.32.0 || ^8.2.0",

--- a/tests/__snapshots__/config@eslint-config-standard
+++ b/tests/__snapshots__/config@eslint-config-standard
@@ -13,7 +13,8 @@ const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.c
 
 export default defineConfig([
   compat.extends("standard"),
-]);",
+]);
+",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard-flat
+++ b/tests/__snapshots__/config@eslint-config-standard-flat
@@ -5,7 +5,8 @@ import { defineConfig } from "@eslint/config-helpers";
 
 export default defineConfig([
   config,
-]);",
+]);
+",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-standard-flat2
+++ b/tests/__snapshots__/config@eslint-config-standard-flat2
@@ -5,7 +5,8 @@ import { defineConfig } from "@eslint/config-helpers";
 
 export default defineConfig([
   config,
-]);",
+]);
+",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@^8.0.1",

--- a/tests/__snapshots__/config@eslint-config-xo
+++ b/tests/__snapshots__/config@eslint-config-xo
@@ -5,7 +5,8 @@ import { defineConfig } from "eslint/config";
 
 export default defineConfig([
   config,
-]);",
+]);
+",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint@>=9.25.0",

--- a/tests/__snapshots__/empty
+++ b/tests/__snapshots__/empty
@@ -4,7 +4,8 @@
 
 export default defineConfig([
   {}
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-css-problems
+++ b/tests/__snapshots__/esm-css-problems
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.css"], plugins: { css }, language: "css/css", extends: ["css/recommended"] },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-css-syntax
+++ b/tests/__snapshots__/esm-css-syntax
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.css"], plugins: { css }, language: "css/css" },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-javascript-json-problems
+++ b/tests/__snapshots__/esm-javascript-json-problems
@@ -9,7 +9,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: globals.node } },
   { files: ["**/*.json"], plugins: { json }, language: "json/json", extends: ["json/recommended"] },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-json-problems
+++ b/tests/__snapshots__/esm-json-problems
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json"], plugins: { json }, language: "json/json", extends: ["json/recommended"] },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-json-syntax
+++ b/tests/__snapshots__/esm-json-syntax
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json"], plugins: { json }, language: "json/json" },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-json5-problems
+++ b/tests/__snapshots__/esm-json5-problems
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json5"], plugins: { json }, language: "json/json5", extends: ["json/recommended"] },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-json5-syntax
+++ b/tests/__snapshots__/esm-json5-syntax
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json5"], plugins: { json }, language: "json/json5" },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-jsonc-problems
+++ b/tests/__snapshots__/esm-jsonc-problems
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.jsonc"], plugins: { json }, language: "json/jsonc", extends: ["json/recommended"] },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-jsonc-syntax
+++ b/tests/__snapshots__/esm-jsonc-syntax
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.jsonc"], plugins: { json }, language: "json/jsonc" },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-markdown-commonmark-problems
+++ b/tests/__snapshots__/esm-markdown-commonmark-problems
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/commonmark", extends: ["markdown/recommended"] },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-markdown-commonmark-syntax
+++ b/tests/__snapshots__/esm-markdown-commonmark-syntax
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/commonmark" },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-markdown-gfm-problems
+++ b/tests/__snapshots__/esm-markdown-gfm-problems
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/gfm", extends: ["markdown/recommended"] },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/esm-markdown-gfm-syntax
+++ b/tests/__snapshots__/esm-markdown-gfm-syntax
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/gfm" },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-none-javascript
+++ b/tests/__snapshots__/problems-commonjs-none-javascript
@@ -8,7 +8,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -10,7 +10,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-react-javascript
+++ b/tests/__snapshots__/problems-commonjs-react-javascript
@@ -10,7 +10,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -12,7 +12,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-vue-javascript
+++ b/tests/__snapshots__/problems-commonjs-vue-javascript
@@ -10,7 +10,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -13,7 +13,8 @@ export default defineConfig([
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-none-javascript
+++ b/tests/__snapshots__/problems-esm-none-javascript
@@ -7,7 +7,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -9,7 +9,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-react-javascript
+++ b/tests/__snapshots__/problems-esm-react-javascript
@@ -9,7 +9,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -11,7 +11,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-vue-javascript
+++ b/tests/__snapshots__/problems-esm-vue-javascript
@@ -9,7 +9,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -12,7 +12,8 @@ export default defineConfig([
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-none-javascript
+++ b/tests/__snapshots__/problems-script-none-javascript
@@ -8,7 +8,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -10,7 +10,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-react-javascript
+++ b/tests/__snapshots__/problems-script-react-javascript
@@ -10,7 +10,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -12,7 +12,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-vue-javascript
+++ b/tests/__snapshots__/problems-script-vue-javascript
@@ -10,7 +10,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -13,7 +13,8 @@ export default defineConfig([
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-none-javascript
+++ b/tests/__snapshots__/syntax-commonjs-none-javascript
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-none-typescript
+++ b/tests/__snapshots__/syntax-commonjs-none-typescript
@@ -8,7 +8,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-javascript
+++ b/tests/__snapshots__/syntax-commonjs-react-javascript
@@ -8,7 +8,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-react-typescript
+++ b/tests/__snapshots__/syntax-commonjs-react-typescript
@@ -10,7 +10,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-vue-javascript
+++ b/tests/__snapshots__/syntax-commonjs-vue-javascript
@@ -8,7 +8,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-commonjs-vue-typescript
+++ b/tests/__snapshots__/syntax-commonjs-vue-typescript
@@ -11,7 +11,8 @@ export default defineConfig([
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-none-javascript
+++ b/tests/__snapshots__/syntax-esm-none-javascript
@@ -5,7 +5,8 @@ import { defineConfig } from "eslint/config";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-none-typescript
+++ b/tests/__snapshots__/syntax-esm-none-typescript
@@ -7,7 +7,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-javascript
+++ b/tests/__snapshots__/syntax-esm-react-javascript
@@ -7,7 +7,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-react-typescript
+++ b/tests/__snapshots__/syntax-esm-react-typescript
@@ -9,7 +9,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-vue-javascript
+++ b/tests/__snapshots__/syntax-esm-vue-javascript
@@ -7,7 +7,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-esm-vue-typescript
+++ b/tests/__snapshots__/syntax-esm-vue-typescript
@@ -10,7 +10,8 @@ export default defineConfig([
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-none-javascript
+++ b/tests/__snapshots__/syntax-script-none-javascript
@@ -6,7 +6,8 @@ import { defineConfig } from "eslint/config";
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-none-typescript
+++ b/tests/__snapshots__/syntax-script-none-typescript
@@ -8,7 +8,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-react-javascript
+++ b/tests/__snapshots__/syntax-script-react-javascript
@@ -8,7 +8,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-react-typescript
+++ b/tests/__snapshots__/syntax-script-react-typescript
@@ -10,7 +10,8 @@ export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-vue-javascript
+++ b/tests/__snapshots__/syntax-script-vue-javascript
@@ -8,7 +8,8 @@ export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/__snapshots__/syntax-script-vue-typescript
+++ b/tests/__snapshots__/syntax-script-vue-typescript
@@ -11,7 +11,8 @@ export default defineConfig([
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
-]);",
+]);
+",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",

--- a/tests/config-snapshots.spec.js
+++ b/tests/config-snapshots.spec.js
@@ -79,6 +79,7 @@ describe("generate config for esm projects", () => {
 
             expect(generator.result.configFilename).toBe("eslint.config.js");
             expect(generator.packageJsonPath).toBe(join(esmProjectDir, "./package.json"));
+            expect(generator.result.configContent.endsWith("\n")).toBe(true);
             expect(generator.result).toMatchFileSnapshot(`./__snapshots__/${item.name}`);
         });
     });
@@ -138,6 +139,7 @@ describe("generate config for cjs projects", () => {
 
             expect(generator.result.configFilename).toBe("eslint.config.mjs");
             expect(generator.packageJsonPath).toBe(join(cjsProjectDir, "./package.json"));
+            expect(generator.result.configContent.endsWith("\n")).toBe(true);
             expect(generator.result).toMatchFileSnapshot(`./__snapshots__/${item.name}`);
         });
     });


### PR DESCRIPTION
This PR addresses the missing end-of-line (EOL) at the end of generated config files. By ensuring a proper newline is present, it maintains POSIX compliance and prevents editors from introducing unintended changes due to the absence of a final EOL.