### PR TITLE
chore: use `defineConfig` and `globalIgnores` in ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,13 +1,9 @@
+import { defineConfig, globalIgnores } from "eslint/config";
 import eslintConfigESLint from "eslint-config-eslint";
 import eslintConfigESLintFormatting from "eslint-config-eslint/formatting";
 
-export default [
-    {
-        ignores: [
-            "coverage/",
-            "tests/fixtures/"
-        ]
-    },
-    ...eslintConfigESLint,
+export default defineConfig([
+    globalIgnores(["coverage/", "tests/fixtures/"]),
+    eslintConfigESLint,
     eslintConfigESLintFormatting
-];
+]);

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     },
     "devDependencies": {
         "@vitest/coverage-v8": "^1.3.1",
-        "eslint": "^9.4.0",
+        "eslint": "^9.27.0",
         "eslint-config-eslint": "^11.0.0",
         "eslint-release": "^3.2.0",
         "lint-staged": "^12.1.2",


### PR DESCRIPTION
Hello,

In this PR, I've updated `eslint.config.js` to use `defineConfig` and `globalIgnores`.

I've also bumped ESLint to the latest version.
