### PR TITLE
refactor: combine environment config with base config

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -60,6 +60,31 @@ const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({baseDirectory: __dirname, recommendedConfig: js.configs.recommended});
 `;
 
+/**
+ * Adds environment configuration to the ESLint config.
+ * @param {Object} options The options for adding environment config.
+ * @param {string[]} options.env The environment types to add.
+ * @param {string[]} options.devDependencies The dev dependencies array to modify.
+ * @returns {{config: string, importContent: string}} The environment configuration content and import statement.
+ */
+function addEnvironmentConfig({ env, devDependencies }) {
+    if (!env?.length) {
+        return { config: "", importContent: "" };
+    }
+
+    devDependencies.push("globals");
+    const envContent = {
+        browser: "globals: globals.browser",
+        node: "globals: globals.node",
+        "browser,node": "globals: {...globals.browser, ...globals.node}"
+    };
+
+    return {
+        config: `languageOptions: { ${envContent[env.join(",")]} }`,
+        importContent: "import globals from \"globals\";\n"
+    };
+}
+
 //-----------------------------------------------------------------------------
 // Exports
 //-----------------------------------------------------------------------------
@@ -133,23 +158,34 @@ export class ConfigGenerator {
             if (purpose === "problems") {
                 this.result.devDependencies.push("@eslint/js");
                 importContent += "import js from \"@eslint/js\";\n";
-                exportContent += `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended"] },\n`;
+                let configContent = `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended"]`;
+
+                const { config, importContent: envImport } = addEnvironmentConfig({
+                    env: this.answers.env,
+                    devDependencies: this.result.devDependencies
+                });
+
+                importContent += envImport;
+                if (config) {
+                    configContent += `, ${config}`;
+                }
+
+                exportContent += `${configContent} },\n`;
             }
 
             if (this.answers.moduleType === "commonjs" || this.answers.moduleType === "script") {
                 exportContent += `  { files: ["**/*.js"], languageOptions: { sourceType: "${this.answers.moduleType}" } },\n`;
             }
 
-            if (this.answers.env?.length > 0) {
-                this.result.devDependencies.push("globals");
-                importContent += "import globals from \"globals\";\n";
-                const envContent = {
-                    browser: "globals: globals.browser",
-                    node: "globals: globals.node",
-                    "browser,node": "globals: {...globals.browser, ...globals.node}"
-                };
+            if (this.answers.env?.length > 0 && purpose !== "problems") {
+                const { config, importContent: envImport } = addEnvironmentConfig({
+                    env: this.answers.env,
+                    devDependencies: this.result.devDependencies
+                });
 
-                exportContent += `  { files: ["${extensions}"], languageOptions: { ${envContent[this.answers.env.join(",")]} } },\n`;
+                importContent += envImport;
+
+                exportContent += `  { files: ["${extensions}"], ${config} },\n`;
             }
             if (useTs) {
                 this.result.devDependencies.push("typescript-eslint");

--- a/tests/__snapshots__/esm-javascript-json-problems
+++ b/tests/__snapshots__/esm-javascript-json-problems
@@ -6,8 +6,7 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
-  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: globals.node } },
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
   { files: ["**/*.json"], plugins: { json }, language: "json/json", extends: ["json/recommended"] },
 ]);
 ",

--- a/tests/__snapshots__/problems-commonjs-none-javascript
+++ b/tests/__snapshots__/problems-commonjs-none-javascript
@@ -5,9 +5,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
 ]);
 ",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -6,9 +6,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
 ]);
 ",

--- a/tests/__snapshots__/problems-commonjs-react-javascript
+++ b/tests/__snapshots__/problems-commonjs-react-javascript
@@ -6,9 +6,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
 ]);
 ",

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -7,9 +7,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);

--- a/tests/__snapshots__/problems-commonjs-vue-javascript
+++ b/tests/__snapshots__/problems-commonjs-vue-javascript
@@ -6,9 +6,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
 ]);
 ",

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -7,9 +7,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },

--- a/tests/__snapshots__/problems-esm-none-javascript
+++ b/tests/__snapshots__/problems-esm-none-javascript
@@ -5,8 +5,7 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
-  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
 ]);
 ",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -6,8 +6,7 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
-  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
 ]);
 ",

--- a/tests/__snapshots__/problems-esm-react-javascript
+++ b/tests/__snapshots__/problems-esm-react-javascript
@@ -6,8 +6,7 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
-  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
 ]);
 ",

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -7,8 +7,7 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
-  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);

--- a/tests/__snapshots__/problems-esm-vue-javascript
+++ b/tests/__snapshots__/problems-esm-vue-javascript
@@ -6,8 +6,7 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
-  { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
 ]);
 ",

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -7,8 +7,7 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
-  { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },

--- a/tests/__snapshots__/problems-script-none-javascript
+++ b/tests/__snapshots__/problems-script-none-javascript
@@ -5,9 +5,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
 ]);
 ",
   "configFilename": "eslint.config.js",

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -6,9 +6,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.{js,mjs,cjs,ts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
 ]);
 ",

--- a/tests/__snapshots__/problems-script-react-javascript
+++ b/tests/__snapshots__/problems-script-react-javascript
@@ -6,9 +6,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
 ]);
 ",

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -7,9 +7,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);

--- a/tests/__snapshots__/problems-script-vue-javascript
+++ b/tests/__snapshots__/problems-script-vue-javascript
@@ -6,9 +6,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
 ]);
 ",

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -7,9 +7,8 @@ import { defineConfig } from "eslint/config";
 
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"] },
+  { files: ["**/*.{js,mjs,cjs,ts,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  { files: ["**/*.{js,mjs,cjs,ts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },


### PR DESCRIPTION
When generating ESLint configs with environment globals, combine them into a single config object instead of creating separate objects. This simplifies the output and prevents potential confusion for users who might think multiple objects are necessary.

Fixes #171 