### PR TITLE
fix: remove double blank lines when not use eslintrc style

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -343,7 +343,7 @@ export class ConfigGenerator {
             this.result.devDependencies.push("jiti");
         }
 
-        this.result.configContent = `${importContent}
+        this.result.configContent = `${needCompatHelper ? importContent : importContent.slice(0, -1)}
 ${needCompatHelper ? helperContent : ""}
 export default defineConfig([\n${exportContent || "  {}\n"}]);\n`; // defaults to `[{}]` to avoid empty config warning
     }

--- a/tests/__snapshots__/cjs-configfile-js
+++ b/tests/__snapshots__/cjs-configfile-js
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/cjs-configfile-ts
+++ b/tests/__snapshots__/cjs-configfile-ts
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/cjs-configfile-ts-jiti
+++ b/tests/__snapshots__/cjs-configfile-ts-jiti
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/config@eslint-config-standard-flat
+++ b/tests/__snapshots__/config@eslint-config-standard-flat
@@ -2,7 +2,6 @@
   "configContent": "import config from "eslint-config-standard";
 import { defineConfig } from "@eslint/config-helpers";
 
-
 export default defineConfig([
   config,
 ]);

--- a/tests/__snapshots__/config@eslint-config-standard-flat2
+++ b/tests/__snapshots__/config@eslint-config-standard-flat2
@@ -2,7 +2,6 @@
   "configContent": "import config from "eslint-config-standard";
 import { defineConfig } from "@eslint/config-helpers";
 
-
 export default defineConfig([
   config,
 ]);

--- a/tests/__snapshots__/config@eslint-config-xo
+++ b/tests/__snapshots__/config@eslint-config-xo
@@ -2,7 +2,6 @@
   "configContent": "import config from "eslint-config-xo";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   config,
 ]);

--- a/tests/__snapshots__/empty
+++ b/tests/__snapshots__/empty
@@ -1,7 +1,6 @@
 {
   "configContent": "import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   {}
 ]);

--- a/tests/__snapshots__/esm-configfile-js
+++ b/tests/__snapshots__/esm-configfile-js
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
   tseslint.configs.recommended,

--- a/tests/__snapshots__/esm-configfile-ts
+++ b/tests/__snapshots__/esm-configfile-ts
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
   tseslint.configs.recommended,

--- a/tests/__snapshots__/esm-configfile-ts-jiti
+++ b/tests/__snapshots__/esm-configfile-ts-jiti
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
   tseslint.configs.recommended,

--- a/tests/__snapshots__/esm-css-problems
+++ b/tests/__snapshots__/esm-css-problems
@@ -2,7 +2,6 @@
   "configContent": "import css from "@eslint/css";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.css"], plugins: { css }, language: "css/css", extends: ["css/recommended"] },

--- a/tests/__snapshots__/esm-css-syntax
+++ b/tests/__snapshots__/esm-css-syntax
@@ -2,7 +2,6 @@
   "configContent": "import css from "@eslint/css";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.css"], plugins: { css }, language: "css/css" },

--- a/tests/__snapshots__/esm-javascript-json-problems
+++ b/tests/__snapshots__/esm-javascript-json-problems
@@ -4,7 +4,6 @@ import globals from "globals";
 import json from "@eslint/json";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
   { files: ["**/*.json"], plugins: { json }, language: "json/json", extends: ["json/recommended"] },

--- a/tests/__snapshots__/esm-json-problems
+++ b/tests/__snapshots__/esm-json-problems
@@ -2,7 +2,6 @@
   "configContent": "import json from "@eslint/json";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json"], plugins: { json }, language: "json/json", extends: ["json/recommended"] },

--- a/tests/__snapshots__/esm-json-syntax
+++ b/tests/__snapshots__/esm-json-syntax
@@ -2,7 +2,6 @@
   "configContent": "import json from "@eslint/json";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json"], plugins: { json }, language: "json/json" },

--- a/tests/__snapshots__/esm-json5-problems
+++ b/tests/__snapshots__/esm-json5-problems
@@ -2,7 +2,6 @@
   "configContent": "import json from "@eslint/json";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json5"], plugins: { json }, language: "json/json5", extends: ["json/recommended"] },

--- a/tests/__snapshots__/esm-json5-syntax
+++ b/tests/__snapshots__/esm-json5-syntax
@@ -2,7 +2,6 @@
   "configContent": "import json from "@eslint/json";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.json5"], plugins: { json }, language: "json/json5" },

--- a/tests/__snapshots__/esm-jsonc-problems
+++ b/tests/__snapshots__/esm-jsonc-problems
@@ -2,7 +2,6 @@
   "configContent": "import json from "@eslint/json";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.jsonc"], plugins: { json }, language: "json/jsonc", extends: ["json/recommended"] },

--- a/tests/__snapshots__/esm-jsonc-syntax
+++ b/tests/__snapshots__/esm-jsonc-syntax
@@ -2,7 +2,6 @@
   "configContent": "import json from "@eslint/json";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.jsonc"], plugins: { json }, language: "json/jsonc" },

--- a/tests/__snapshots__/esm-markdown-commonmark-problems
+++ b/tests/__snapshots__/esm-markdown-commonmark-problems
@@ -2,7 +2,6 @@
   "configContent": "import markdown from "@eslint/markdown";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/commonmark", extends: ["markdown/recommended"] },

--- a/tests/__snapshots__/esm-markdown-commonmark-syntax
+++ b/tests/__snapshots__/esm-markdown-commonmark-syntax
@@ -2,7 +2,6 @@
   "configContent": "import markdown from "@eslint/markdown";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/commonmark" },

--- a/tests/__snapshots__/esm-markdown-gfm-problems
+++ b/tests/__snapshots__/esm-markdown-gfm-problems
@@ -2,7 +2,6 @@
   "configContent": "import markdown from "@eslint/markdown";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/gfm", extends: ["markdown/recommended"] },

--- a/tests/__snapshots__/esm-markdown-gfm-syntax
+++ b/tests/__snapshots__/esm-markdown-gfm-syntax
@@ -2,7 +2,6 @@
   "configContent": "import markdown from "@eslint/markdown";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { ignores: ["**/*.js", "**/*.cjs", "**/*.mjs"] },
   { files: ["**/*.md"], plugins: { markdown }, language: "markdown/gfm" },

--- a/tests/__snapshots__/problems-commonjs-none-javascript
+++ b/tests/__snapshots__/problems-commonjs-none-javascript
@@ -3,7 +3,6 @@
 import globals from "globals";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/problems-commonjs-react-javascript
+++ b/tests/__snapshots__/problems-commonjs-react-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/problems-commonjs-vue-javascript
+++ b/tests/__snapshots__/problems-commonjs-vue-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },

--- a/tests/__snapshots__/problems-esm-none-javascript
+++ b/tests/__snapshots__/problems-esm-none-javascript
@@ -3,7 +3,6 @@
 import globals from "globals";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
 ]);

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,

--- a/tests/__snapshots__/problems-esm-react-javascript
+++ b/tests/__snapshots__/problems-esm-react-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,

--- a/tests/__snapshots__/problems-esm-vue-javascript
+++ b/tests/__snapshots__/problems-esm-vue-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,

--- a/tests/__snapshots__/problems-script-none-javascript
+++ b/tests/__snapshots__/problems-script-none-javascript
@@ -3,7 +3,6 @@
 import globals from "globals";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -4,7 +4,6 @@ import globals from "globals";
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/problems-script-react-javascript
+++ b/tests/__snapshots__/problems-script-react-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/problems-script-vue-javascript
+++ b/tests/__snapshots__/problems-script-vue-javascript
@@ -4,7 +4,6 @@ import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -5,7 +5,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },

--- a/tests/__snapshots__/syntax-commonjs-none-javascript
+++ b/tests/__snapshots__/syntax-commonjs-none-javascript
@@ -2,7 +2,6 @@
   "configContent": "import globals from "globals";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-commonjs-none-typescript
+++ b/tests/__snapshots__/syntax-commonjs-none-typescript
@@ -3,7 +3,6 @@
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-commonjs-react-javascript
+++ b/tests/__snapshots__/syntax-commonjs-react-javascript
@@ -3,7 +3,6 @@
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-commonjs-react-typescript
+++ b/tests/__snapshots__/syntax-commonjs-react-typescript
@@ -4,7 +4,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-commonjs-vue-javascript
+++ b/tests/__snapshots__/syntax-commonjs-vue-javascript
@@ -3,7 +3,6 @@
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-commonjs-vue-typescript
+++ b/tests/__snapshots__/syntax-commonjs-vue-typescript
@@ -4,7 +4,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-esm-none-javascript
+++ b/tests/__snapshots__/syntax-esm-none-javascript
@@ -2,7 +2,6 @@
   "configContent": "import globals from "globals";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
 ]);

--- a/tests/__snapshots__/syntax-esm-none-typescript
+++ b/tests/__snapshots__/syntax-esm-none-typescript
@@ -3,7 +3,6 @@
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,

--- a/tests/__snapshots__/syntax-esm-react-javascript
+++ b/tests/__snapshots__/syntax-esm-react-javascript
@@ -3,7 +3,6 @@
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,

--- a/tests/__snapshots__/syntax-esm-react-typescript
+++ b/tests/__snapshots__/syntax-esm-react-typescript
@@ -4,7 +4,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,

--- a/tests/__snapshots__/syntax-esm-vue-javascript
+++ b/tests/__snapshots__/syntax-esm-vue-javascript
@@ -3,7 +3,6 @@
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],

--- a/tests/__snapshots__/syntax-esm-vue-typescript
+++ b/tests/__snapshots__/syntax-esm-vue-typescript
@@ -4,7 +4,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   tseslint.configs.recommended,

--- a/tests/__snapshots__/syntax-script-none-javascript
+++ b/tests/__snapshots__/syntax-script-none-javascript
@@ -2,7 +2,6 @@
   "configContent": "import globals from "globals";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-script-none-typescript
+++ b/tests/__snapshots__/syntax-script-none-typescript
@@ -3,7 +3,6 @@
 import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-script-react-javascript
+++ b/tests/__snapshots__/syntax-script-react-javascript
@@ -3,7 +3,6 @@
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,jsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-script-react-typescript
+++ b/tests/__snapshots__/syntax-script-react-typescript
@@ -4,7 +4,6 @@ import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-script-vue-javascript
+++ b/tests/__snapshots__/syntax-script-vue-javascript
@@ -3,7 +3,6 @@
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },

--- a/tests/__snapshots__/syntax-script-vue-typescript
+++ b/tests/__snapshots__/syntax-script-vue-typescript
@@ -4,7 +4,6 @@ import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
-
 export default defineConfig([
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
   { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], languageOptions: { globals: {...globals.browser, ...globals.node} } },


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

To fix **double blank lines** when **NOT** use `eslintrc` config style.

#### What changes did you make? (Give an overview)

Before:

```js
// Import...
import { defineConfig } from "eslint";


export default defineConfig([
  // Config...
])
```

After:

```js
// Import...
import { defineConfig } from "eslint";

export default defineConfig([
  // Config...
])
```

#### Related Issues

N/A

#### Is there anything you'd like reviewers to focus on?

N/A