### PR TITLE
fix: exit gracefully on `Ctrl+C`

### DIFF
--- a/bin/create-config.js
+++ b/bin/create-config.js
@@ -17,6 +17,7 @@ info(`${pkg.name}: v${pkg.version}\n`);
 
 process.on("uncaughtException", error => {
     if (error instanceof Error && error.code === "ERR_USE_AFTER_CLOSE") {
+        info("Operation canceled");
         // eslint-disable-next-line n/no-process-exit -- exit gracefully on Ctrl+C
         process.exit(1);
     } else {


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### What is the purpose of this pull request?

Prevent a crash when pressing `Ctrl+C` by exiting gracefully.

#### What changes did you make? (Give an overview)

Added an `uncaughtException` handler that catches `ERR_USE_AFTER_CLOSE` and calls `process.exit(1)`, rethrowing other errors.

#### Related Issues

Fixes #192 

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?
