### PR TITLE
test: replace `sinon` with `vitest` mocks in tests for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "lint-staged": "^16.2.7",
     "memfs": "^4.0.0",
     "prettier": "3.8.1",
-    "sinon": "^21.0.0",
     "vitest": "^4.0.18",
     "yorkie": "^2.0.0"
   },

--- a/tests/utils/npm-utils.spec.js
+++ b/tests/utils/npm-utils.spec.js
@@ -19,7 +19,6 @@ import {
 import { defineInMemoryFs } from "../_utils/in-memory-fs.js";
 import { assert, describe, afterEach, it, expect, vi } from "vitest";
 import fs from "node:fs";
-import process from "node:process";
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -291,36 +290,31 @@ describe("npmUtils", () => {
 	});
 
 	describe("fetchPeerDependencies()", () => {
-		// Skip on Node.js v21 due to a bug where fetch cannot be stubbed
-		// See: https://github.com/sinonjs/sinon/issues/2590
-		it.skipIf(process.version.startsWith("v21"))(
-			"should fetch peer dependencies from npm registry",
-			async () => {
-				const mockResponse = {
-					json: vi.fn().mockResolvedValue({
-						"dist-tags": { latest: "9.0.0" },
-						versions: {
-							"9.0.0": {
-								peerDependencies: { eslint: "9.0.0" },
-							},
+		it("should fetch peer dependencies from npm registry", async () => {
+			const mockResponse = {
+				json: vi.fn().mockResolvedValue({
+					"dist-tags": { latest: "9.0.0" },
+					versions: {
+						"9.0.0": {
+							peerDependencies: { eslint: "9.0.0" },
 						},
-					}),
-					ok: true,
-					status: 200,
-				};
-				const fetchStub = vi
-					.spyOn(globalThis, "fetch")
-					.mockResolvedValue(mockResponse);
+					},
+				}),
+				ok: true,
+				status: 200,
+			};
+			const fetchStub = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(mockResponse);
 
-				const result = await fetchPeerDependencies("desired-package");
+			const result = await fetchPeerDependencies("desired-package");
 
-				assert.strictEqual(fetchStub.mock.calls.length, 1);
-				assert.deepStrictEqual(fetchStub.mock.calls[0], [
-					"https://registry.npmjs.org/desired-package",
-				]);
-				assert.deepStrictEqual(result, ["eslint@9.0.0"]);
-			},
-		);
+			assert.strictEqual(fetchStub.mock.calls.length, 1);
+			assert.deepStrictEqual(fetchStub.mock.calls[0], [
+				"https://registry.npmjs.org/desired-package",
+			]);
+			assert.deepStrictEqual(result, ["eslint@9.0.0"]);
+		});
 
 		it("should handle package with version tag", async () => {
 			const mockResponse = {

--- a/tests/utils/npm-utils.spec.js
+++ b/tests/utils/npm-utils.spec.js
@@ -187,7 +187,6 @@ describe("npmUtils", () => {
 				"-D",
 				"desired-package",
 			]);
-			stub.mockRestore();
 		});
 
 		it("should invoke yarn to install a single desired package", () => {
@@ -203,7 +202,6 @@ describe("npmUtils", () => {
 				"-D",
 				"desired-package",
 			]);
-			stub.mockRestore();
 		});
 
 		it("should invoke bun to install a single desired package", () => {
@@ -219,7 +217,6 @@ describe("npmUtils", () => {
 				"-D",
 				"desired-package",
 			]);
-			stub.mockRestore();
 		});
 
 		it("should accept an array of packages to install", () => {
@@ -236,13 +233,12 @@ describe("npmUtils", () => {
 				"first-package",
 				"second-package",
 			]);
-			stub.mockRestore();
 		});
 
 		it("should log an error message if npm throws ENOENT error", async () => {
-			const npmUtilsStub = vi
-				.spyOn(spawn, "sync")
-				.mockReturnValue({ error: { code: "ENOENT" } });
+			vi.spyOn(spawn, "sync").mockReturnValue({
+				error: { code: "ENOENT" },
+			});
 			const log = await import("../../lib/utils/logging.js");
 			const logErrorStub = vi
 				.spyOn(log, "error")
@@ -251,8 +247,6 @@ describe("npmUtils", () => {
 			installSyncSaveDev("some-package");
 
 			assert.strictEqual(logErrorStub.mock.calls.length, 1);
-
-			npmUtilsStub.mockRestore();
 		});
 	});
 
@@ -325,8 +319,6 @@ describe("npmUtils", () => {
 					"https://registry.npmjs.org/desired-package",
 				]);
 				assert.deepStrictEqual(result, ["eslint@9.0.0"]);
-
-				fetchStub.mockRestore();
 			},
 		);
 
@@ -349,15 +341,11 @@ describe("npmUtils", () => {
 				ok: true,
 				status: 200,
 			};
-			const stub = vi
-				.spyOn(globalThis, "fetch")
-				.mockResolvedValue(mockResponse);
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse);
 
 			await expect(
 				fetchPeerDependencies("desired-package@8"),
 			).resolves.toEqual(["eslint@8.0.0"]);
-
-			stub.mockRestore();
 		});
 
 		it("should handle package with dist tag", async () => {
@@ -382,15 +370,11 @@ describe("npmUtils", () => {
 				ok: true,
 				status: 200,
 			};
-			const stub = vi
-				.spyOn(globalThis, "fetch")
-				.mockResolvedValue(mockResponse);
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse);
 
 			await expect(
 				fetchPeerDependencies("desired-package@legacy"),
 			).resolves.toEqual(["eslint@7.0.0"]);
-
-			stub.mockRestore();
 		});
 
 		it("should throw if an error is thrown", async () => {
@@ -399,15 +383,11 @@ describe("npmUtils", () => {
 				ok: false,
 				status: 404,
 			};
-			const stub = vi
-				.spyOn(globalThis, "fetch")
-				.mockResolvedValue(mockResponse);
+			vi.spyOn(globalThis, "fetch").mockResolvedValue(mockResponse);
 
 			await expect(() =>
 				fetchPeerDependencies("desired-package"),
 			).rejects.toThrowError();
-
-			stub.mockRestore();
 		});
 	});
 });

--- a/tests/utils/npm-utils.spec.js
+++ b/tests/utils/npm-utils.spec.js
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 import spawn from "cross-spawn";
-import sinon from "sinon";
 import {
 	installSyncSaveDev,
 	fetchPeerDependencies,
@@ -18,7 +17,7 @@ import {
 	parsePackageName,
 } from "../../lib/utils/npm-utils.js";
 import { defineInMemoryFs } from "../_utils/in-memory-fs.js";
-import { assert, describe, afterEach, it, expect } from "vitest";
+import { assert, describe, afterEach, it, expect, vi } from "vitest";
 import fs from "node:fs";
 import process from "node:process";
 
@@ -34,9 +33,9 @@ import process from "node:process";
 async function useInMemoryFileSystem(files) {
 	const inMemoryFs = defineInMemoryFs({ files });
 
-	sinon.replace(fs, "readFileSync", inMemoryFs.readFileSync);
-	sinon.replace(fs, "existsSync", inMemoryFs.existsSync);
-	sinon.replace(fs, "statSync", inMemoryFs.statSync);
+	vi.spyOn(fs, "readFileSync").mockImplementation(inMemoryFs.readFileSync);
+	vi.spyOn(fs, "existsSync").mockImplementation(inMemoryFs.existsSync);
+	vi.spyOn(fs, "statSync").mockImplementation(inMemoryFs.statSync);
 }
 
 //------------------------------------------------------------------------------
@@ -45,7 +44,7 @@ async function useInMemoryFileSystem(files) {
 
 describe("npmUtils", () => {
 	afterEach(() => {
-		sinon.verifyAndRestore();
+		vi.restoreAllMocks();
 	});
 
 	describe("checkDevDeps()", () => {
@@ -176,76 +175,84 @@ describe("npmUtils", () => {
 
 	describe("installSyncSaveDev()", () => {
 		it("should invoke npm to install a single desired package", () => {
-			const stub = sinon.stub(spawn, "sync").returns({ stdout: "" });
+			const stub = vi
+				.spyOn(spawn, "sync")
+				.mockReturnValue({ stdout: "" });
 
 			installSyncSaveDev("desired-package", "npm");
-			assert(stub.calledOnce);
-			assert.strictEqual(stub.firstCall.args[0], "npm");
-			assert.deepStrictEqual(stub.firstCall.args[1], [
+			assert.strictEqual(stub.mock.calls.length, 1);
+			assert.strictEqual(stub.mock.calls[0][0], "npm");
+			assert.deepStrictEqual(stub.mock.calls[0][1], [
 				"install",
 				"-D",
 				"desired-package",
 			]);
-			stub.restore();
+			stub.mockRestore();
 		});
 
 		it("should invoke yarn to install a single desired package", () => {
-			const stub = sinon.stub(spawn, "sync").returns({ stdout: "" });
+			const stub = vi
+				.spyOn(spawn, "sync")
+				.mockReturnValue({ stdout: "" });
 
 			installSyncSaveDev("desired-package", "yarn");
-			assert(stub.calledOnce);
-			assert.strictEqual(stub.firstCall.args[0], "yarn");
-			assert.deepStrictEqual(stub.firstCall.args[1], [
+			assert.strictEqual(stub.mock.calls.length, 1);
+			assert.strictEqual(stub.mock.calls[0][0], "yarn");
+			assert.deepStrictEqual(stub.mock.calls[0][1], [
 				"add",
 				"-D",
 				"desired-package",
 			]);
-			stub.restore();
+			stub.mockRestore();
 		});
 
 		it("should invoke bun to install a single desired package", () => {
-			const stub = sinon.stub(spawn, "sync").returns({ stdout: "" });
+			const stub = vi
+				.spyOn(spawn, "sync")
+				.mockReturnValue({ stdout: "" });
 
 			installSyncSaveDev("desired-package", "bun");
-			assert(stub.calledOnce);
-			assert.strictEqual(stub.firstCall.args[0], "bun");
-			assert.deepStrictEqual(stub.firstCall.args[1], [
+			assert.strictEqual(stub.mock.calls.length, 1);
+			assert.strictEqual(stub.mock.calls[0][0], "bun");
+			assert.deepStrictEqual(stub.mock.calls[0][1], [
 				"install",
 				"-D",
 				"desired-package",
 			]);
-			stub.restore();
+			stub.mockRestore();
 		});
 
 		it("should accept an array of packages to install", () => {
-			const stub = sinon.stub(spawn, "sync").returns({ stdout: "" });
+			const stub = vi
+				.spyOn(spawn, "sync")
+				.mockReturnValue({ stdout: "" });
 
 			installSyncSaveDev(["first-package", "second-package"], "npm");
-			assert(stub.calledOnce);
-			assert.strictEqual(stub.firstCall.args[0], "npm");
-			assert.deepStrictEqual(stub.firstCall.args[1], [
+			assert.strictEqual(stub.mock.calls.length, 1);
+			assert.strictEqual(stub.mock.calls[0][0], "npm");
+			assert.deepStrictEqual(stub.mock.calls[0][1], [
 				"install",
 				"-D",
 				"first-package",
 				"second-package",
 			]);
-			stub.restore();
+			stub.mockRestore();
 		});
 
 		it("should log an error message if npm throws ENOENT error", async () => {
-			const logErrorStub = sinon.spy();
-			const npmUtilsStub = sinon
-				.stub(spawn, "sync")
-				.returns({ error: { code: "ENOENT" } });
+			const npmUtilsStub = vi
+				.spyOn(spawn, "sync")
+				.mockReturnValue({ error: { code: "ENOENT" } });
 			const log = await import("../../lib/utils/logging.js");
-
-			sinon.replaceGetter(log, "error", () => logErrorStub);
+			const logErrorStub = vi
+				.spyOn(log, "error")
+				.mockImplementation(() => {});
 
 			installSyncSaveDev("some-package");
 
-			assert(logErrorStub.calledOnce);
+			assert.strictEqual(logErrorStub.mock.calls.length, 1);
 
-			npmUtilsStub.restore();
+			npmUtilsStub.mockRestore();
 		});
 	});
 
@@ -295,10 +302,8 @@ describe("npmUtils", () => {
 		it.skipIf(process.version.startsWith("v21"))(
 			"should fetch peer dependencies from npm registry",
 			async () => {
-				const fetchStub = sinon.stub(globalThis, "fetch");
-
 				const mockResponse = {
-					json: sinon.stub().resolves({
+					json: vi.fn().mockResolvedValue({
 						"dist-tags": { latest: "9.0.0" },
 						versions: {
 							"9.0.0": {
@@ -309,27 +314,25 @@ describe("npmUtils", () => {
 					ok: true,
 					status: 200,
 				};
-
-				fetchStub.resolves(mockResponse);
+				const fetchStub = vi
+					.spyOn(globalThis, "fetch")
+					.mockResolvedValue(mockResponse);
 
 				const result = await fetchPeerDependencies("desired-package");
 
-				assert(
-					fetchStub.calledOnceWith(
-						"https://registry.npmjs.org/desired-package",
-					),
-				);
+				assert.strictEqual(fetchStub.mock.calls.length, 1);
+				assert.deepStrictEqual(fetchStub.mock.calls[0], [
+					"https://registry.npmjs.org/desired-package",
+				]);
 				assert.deepStrictEqual(result, ["eslint@9.0.0"]);
 
-				fetchStub.restore();
+				fetchStub.mockRestore();
 			},
 		);
 
 		it("should handle package with version tag", async () => {
-			const stub = sinon.stub(globalThis, "fetch");
-
 			const mockResponse = {
-				json: sinon.stub().resolves({
+				json: vi.fn().mockResolvedValue({
 					"dist-tags": { latest: "9.0.0" },
 					versions: {
 						"9.0.0": {
@@ -346,21 +349,20 @@ describe("npmUtils", () => {
 				ok: true,
 				status: 200,
 			};
-
-			stub.resolves(mockResponse);
+			const stub = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(mockResponse);
 
 			await expect(
 				fetchPeerDependencies("desired-package@8"),
 			).resolves.toEqual(["eslint@8.0.0"]);
 
-			stub.restore();
+			stub.mockRestore();
 		});
 
 		it("should handle package with dist tag", async () => {
-			const stub = sinon.stub(globalThis, "fetch");
-
 			const mockResponse = {
-				json: sinon.stub().resolves({
+				json: vi.fn().mockResolvedValue({
 					"dist-tags": {
 						latest: "9.0.0",
 						legacy: "7.0.0",
@@ -380,32 +382,32 @@ describe("npmUtils", () => {
 				ok: true,
 				status: 200,
 			};
-
-			stub.resolves(mockResponse);
+			const stub = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(mockResponse);
 
 			await expect(
 				fetchPeerDependencies("desired-package@legacy"),
 			).resolves.toEqual(["eslint@7.0.0"]);
 
-			stub.restore();
+			stub.mockRestore();
 		});
 
 		it("should throw if an error is thrown", async () => {
-			const stub = sinon.stub(globalThis, "fetch");
-
 			const mockResponse = {
-				json: sinon.stub().resolves({ error: "Not found" }),
+				json: vi.fn().mockResolvedValue({ error: "Not found" }),
 				ok: false,
 				status: 404,
 			};
-
-			stub.resolves(mockResponse);
+			const stub = vi
+				.spyOn(globalThis, "fetch")
+				.mockResolvedValue(mockResponse);
 
 			await expect(() =>
 				fetchPeerDependencies("desired-package"),
 			).rejects.toThrowError();
 
-			stub.restore();
+			stub.mockRestore();
 		});
 	});
 });

--- a/tests/utils/npm-utils.spec.js
+++ b/tests/utils/npm-utils.spec.js
@@ -29,7 +29,7 @@ import fs from "node:fs";
  * @param {Object} files The file definitions.
  * @returns {void}
  */
-async function useInMemoryFileSystem(files) {
+function useInMemoryFileSystem(files) {
 	const inMemoryFs = defineInMemoryFs({ files });
 
 	vi.spyOn(fs, "readFileSync").mockImplementation(inMemoryFs.readFileSync);
@@ -75,8 +75,8 @@ describe("npmUtils", () => {
 			assert.isFalse(installStatus.notarealpackage);
 		});
 
-		it("should handle missing devDependencies key", async () => {
-			await useInMemoryFileSystem({
+		it("should handle missing devDependencies key", () => {
+			useInMemoryFileSystem({
 				"package.json": JSON.stringify({
 					private: true,
 					dependencies: {},
@@ -87,8 +87,8 @@ describe("npmUtils", () => {
 			checkDevDeps(["some-package"]);
 		});
 
-		it("should throw with message when parsing invalid package.json", async () => {
-			await useInMemoryFileSystem({
+		it("should throw with message when parsing invalid package.json", () => {
+			useInMemoryFileSystem({
 				"package.json": '{ "not: "valid json" }',
 			});
 
@@ -133,8 +133,8 @@ describe("npmUtils", () => {
 			}, "Could not find a package.json file");
 		});
 
-		it("should handle missing dependencies key", async () => {
-			await useInMemoryFileSystem({
+		it("should handle missing dependencies key", () => {
+			useInMemoryFileSystem({
 				"package.json": JSON.stringify({
 					private: true,
 					devDependencies: {},
@@ -145,8 +145,8 @@ describe("npmUtils", () => {
 			checkDeps(["some-package"]);
 		});
 
-		it("should throw with message when parsing invalid package.json", async () => {
-			await useInMemoryFileSystem({
+		it("should throw with message when parsing invalid package.json", () => {
+			useInMemoryFileSystem({
 				"package.json": '{ "not: "valid json" }',
 			});
 
@@ -157,16 +157,16 @@ describe("npmUtils", () => {
 	});
 
 	describe("checkPackageJson()", () => {
-		it("should return true if package.json exists", async () => {
-			await useInMemoryFileSystem({
+		it("should return true if package.json exists", () => {
+			useInMemoryFileSystem({
 				"package.json": '{ "file": "contents" }',
 			});
 
 			assert.strictEqual(checkPackageJson(), true);
 		});
 
-		it("should return false if package.json does not exist", async () => {
-			await useInMemoryFileSystem({});
+		it("should return false if package.json does not exist", () => {
+			useInMemoryFileSystem({});
 
 			assert.strictEqual(checkPackageJson(), false);
 		});
@@ -179,13 +179,11 @@ describe("npmUtils", () => {
 				.mockReturnValue({ stdout: "" });
 
 			installSyncSaveDev("desired-package", "npm");
-			assert.strictEqual(stub.mock.calls.length, 1);
-			assert.strictEqual(stub.mock.calls[0][0], "npm");
-			assert.deepStrictEqual(stub.mock.calls[0][1], [
-				"install",
-				"-D",
-				"desired-package",
-			]);
+			expect(stub).toHaveBeenCalledExactlyOnceWith(
+				"npm",
+				["install", "-D", "desired-package"],
+				{ stdio: "inherit" },
+			);
 		});
 
 		it("should invoke yarn to install a single desired package", () => {
@@ -194,13 +192,11 @@ describe("npmUtils", () => {
 				.mockReturnValue({ stdout: "" });
 
 			installSyncSaveDev("desired-package", "yarn");
-			assert.strictEqual(stub.mock.calls.length, 1);
-			assert.strictEqual(stub.mock.calls[0][0], "yarn");
-			assert.deepStrictEqual(stub.mock.calls[0][1], [
-				"add",
-				"-D",
-				"desired-package",
-			]);
+			expect(stub).toHaveBeenCalledExactlyOnceWith(
+				"yarn",
+				["add", "-D", "desired-package"],
+				{ stdio: "inherit" },
+			);
 		});
 
 		it("should invoke bun to install a single desired package", () => {
@@ -209,13 +205,11 @@ describe("npmUtils", () => {
 				.mockReturnValue({ stdout: "" });
 
 			installSyncSaveDev("desired-package", "bun");
-			assert.strictEqual(stub.mock.calls.length, 1);
-			assert.strictEqual(stub.mock.calls[0][0], "bun");
-			assert.deepStrictEqual(stub.mock.calls[0][1], [
-				"install",
-				"-D",
-				"desired-package",
-			]);
+			expect(stub).toHaveBeenCalledExactlyOnceWith(
+				"bun",
+				["install", "-D", "desired-package"],
+				{ stdio: "inherit" },
+			);
 		});
 
 		it("should accept an array of packages to install", () => {
@@ -224,14 +218,11 @@ describe("npmUtils", () => {
 				.mockReturnValue({ stdout: "" });
 
 			installSyncSaveDev(["first-package", "second-package"], "npm");
-			assert.strictEqual(stub.mock.calls.length, 1);
-			assert.strictEqual(stub.mock.calls[0][0], "npm");
-			assert.deepStrictEqual(stub.mock.calls[0][1], [
-				"install",
-				"-D",
-				"first-package",
-				"second-package",
-			]);
+			expect(stub).toHaveBeenCalledExactlyOnceWith(
+				"npm",
+				["install", "-D", "first-package", "second-package"],
+				{ stdio: "inherit" },
+			);
 		});
 
 		it("should log an error message if npm throws ENOENT error", async () => {
@@ -309,10 +300,9 @@ describe("npmUtils", () => {
 
 			const result = await fetchPeerDependencies("desired-package");
 
-			assert.strictEqual(fetchStub.mock.calls.length, 1);
-			assert.deepStrictEqual(fetchStub.mock.calls[0], [
+			expect(fetchStub).toHaveBeenCalledExactlyOnceWith(
 				"https://registry.npmjs.org/desired-package",
-			]);
+			);
 			assert.deepStrictEqual(result, ["eslint@9.0.0"]);
 		});
 


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR replaces the test mocking library `sinon` with Vitest's native mocking for consistency and simplicity. Vitest already provides mocking utilities natively, so using `sinon` alongside it actually duplicates functionality.

I've ensured that the behavior before and after is consistent.

Vitest `vi` documentation: https://vitest.dev/api/vi.html

#### What changes did you make? (Give an overview)

This PR replaces the test mocking library `sinon` with Vitest's native mocking for consistency and simplicity.

#### Related Issues

N/A

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
