### PR TITLE
ci: add `triage:no` to hide release please PRs from the triage board

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "bootstrap-sha": "232b7becd9f6587d51fbb59cc0da468e62acc9ea",
+  "extra-label": "triage:no",
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Currently the `rewrite` repository sets `"extra-label": "triage:no"`, so Release Please PRs do not appear on the triage board.

https://github.com/eslint/rewrite/blob/main/release-please-config.json#L5

However, some other repositories do not specify this option, which clutters the triage board:

https://github.com/orgs/eslint/projects/3/views/1

<img width="329" height="308" alt="Image" src="https://github.com/user-attachments/assets/13d4c456-a39e-45fd-a230-1661317489c0" />

#### What changes did you make? (Give an overview)

I've added missing `"extra-label": "triage:no"` to `release-please-config.json` to hide Release Please PRs from the triage board.

#### Related Issues

Ref: https://github.com/eslint/workflows/issues/58

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?

N/A
