### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/ci-package-manager.yml
+++ b/.github/workflows/ci-package-manager.yml
@@ -9,6 +9,9 @@ on:
         branches:
             - main
 
+permissions:
+    contents: read
+
 jobs:
     ci-package-manager:
         uses: eslint/workflows/.github/workflows/ci-package-manager.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     pull_request:
         branches:
             - main
+
+permissions:
+    contents: read
+
 jobs:
     lint:
         name: Lint

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -6,6 +6,9 @@ on:
 
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     update-readme:
         uses: eslint/workflows/.github/workflows/update-readme.yml@main


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.