### PR TITLE
chore: fix JSDoc lint warnings

### DIFF
--- a/bin/create-config.js
+++ b/bin/create-config.js
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 
+/* eslint-disable jsdoc/escape-inline-tags -- false positive */
 /**
- * @fileoverview Main CLI that is run via the `npm init \@eslint/config` command.
+ * @fileoverview Main CLI that is run via the `npm init @eslint/config` command.
  * @author 唯然<weiran.zsd@outlook.com>
  */
+/* eslint-enable jsdoc/escape-inline-tags -- false positive */
 
 import { ConfigGenerator } from "../lib/config-generator.js";
 import { findPackageJson } from "../lib/utils/npm-utils.js";

--- a/bin/create-config.js
+++ b/bin/create-config.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * @fileoverview Main CLI that is run via the `npm init @eslint/config` command.
+ * @fileoverview Main CLI that is run via the `npm init \@eslint/config` command.
  * @author 唯然<weiran.zsd@outlook.com>
  */
 

--- a/lib/utils/naming.js
+++ b/lib/utils/naming.js
@@ -1,6 +1,6 @@
 /**
  * Do not change!
- * the file was copied from @eslint/eslintrc, to avoid the dependency on it.
+ * the file was copied from `@eslint/eslintrc`, to avoid the dependency on it.
  * @fileoverview Common helpers for naming of plugins, formatters and configs
  */
 
@@ -44,7 +44,7 @@ function normalizePackageName(name, prefix) {
 		} else if (!scopedPackageNameRegex.test(normalizedName.split("/")[1])) {
 			/**
 			 * for scoped packages, insert the prefix after the first / unless
-			 * the path is already @scope/eslint or @scope/eslint-xxx-yyy
+			 * the path is already `@scope/eslint` or `@scope/eslint-xxx-yyy`
 			 */
 			normalizedName = normalizedName.replace(
 				/^@([^/]+)\/(.*)$/u,


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

This PR fixes `jsdoc/escape-inline-tags` warnings caused by scoped package names being flagged as unescaped tags in non-tag positions.

#### What changes did you make? (Give an overview)

Escaped the `@` symbols in the affected JSDoc comments using backticks or backslashes.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

#### Is there anything you'd like reviewers to focus on?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified inline code references in developer comments.
  - Added linting guidance for a known documentation-rule false positive.

- **Chores**
  - Updated lint configuration comments without changing runtime behavior or CLI functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->