### PR TITLE
fix: use checkbox symbols for multiselect prompts

### DIFF
--- a/lib/questions.js
+++ b/lib/questions.js
@@ -23,16 +23,25 @@ import colors from "ansi-colors";
  * @returns {PlainObject[]} Questions prompt with style options.
  */
 function setQuestionsPromptStyle(questionsPromptArray) {
-	return questionsPromptArray.map(opts => ({
-		...opts,
-		symbols: {
-			// For option symbol in select and multiselect
-			indicator: {
-				on: colors.cyan(colors.symbols.radioOn),
-				off: colors.gray(colors.symbols.radioOff),
+	return questionsPromptArray.map(opts => {
+		const isMultiselect = opts.type === "multiselect";
+
+		return {
+			...opts,
+			symbols: {
+				// Use checkbox symbols for multiselect prompts (multiple choices allowed),
+				// radio symbols for select/toggle prompts (single choice)
+				indicator: {
+					on: isMultiselect
+						? colors.cyan(colors.symbols.ballotOn)
+						: colors.cyan(colors.symbols.radioOn),
+					off: isMultiselect
+						? colors.gray(colors.symbols.ballotOff)
+						: colors.gray(colors.symbols.radioOff),
+				},
 			},
-		},
-	}));
+		};
+	});
 }
 
 // ------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`setQuestionsPromptStyle()` in `lib/questions.js` applies radio-button glyphs (`radioOn`/`radioOff`, rendered as ◉/◯) to **every** prompt, including the two `multiselect` questions ("What do you want to lint?" and "Where does your code run?").

Radio glyphs conventionally mean "pick exactly one." But these prompts actually let you check multiple items with `<space>`. The mismatch leads users to arrow-key-and-Enter through the prompt like a single-choice question, missing that they need to toggle their selection — and the pre-checked default (e.g. "Browser") silently stays selected.

This is likely the root cause behind #74 and #104: in both, the toggle mechanism itself worked, but users didn't realize they needed to use it, because nothing in the UI visually distinguished "checkbox, multiple allowed" from "radio, pick one."

## Fix

Use `ballotOn`/`ballotOff` (☑/☐) for `multiselect`-type prompts specifically, and keep `radioOn`/`radioOff` for `select`/`toggle` prompts, which are genuinely single-choice.

## Testing

- `npm test` — all 93 tests pass, no snapshot changes required
- `npm run lint` — 4 warnings remain, all pre-existing in `bin/create-config.js` and `lib/utils/naming.js` (unrelated to this change, confirmed via `git stash`)
- Manually verified with `node bin/create-config.js`: multiselect prompts now show ☑/☐, single-select prompts unchanged

---

Fixes #74