### PR TITLE
fix: merge tseslint config via extends key in initial config

### DIFF
--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -201,10 +201,10 @@ export class ConfigGenerator {
 				let configContent = "";
 				if (useTs && !isTsConfigAdded) {
 					addTsDependencies();
-					configContent = `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended]`;
+					configContent += `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended]`;
 					isTsConfigAdded = true;
 				} else {
-					configContent = `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended"]`;
+					configContent += `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended"]`;
 				}
 
 				const { config, importContent: envImport } =
@@ -242,6 +242,9 @@ export class ConfigGenerator {
 			if (useTs && !isTsConfigAdded) {
 				addTsDependencies();
 				exportContent += "  tseslint.configs.recommended,\n";
+				/* eslint-disable-next-line no-useless-assignment -- ensure
+					code is extensible if isTsConfigAdded is later used
+				*/
 				isTsConfigAdded = true;
 			}
 

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -189,23 +189,15 @@ export class ConfigGenerator {
 		// language = javascript/typescript
 		if (languages.includes("javascript")) {
 			const useTs = this.answers.useTs;
-			let isTsConfigAdded = false;
-			const addTsDependencies = () => {
-				this.result.devDependencies.push("typescript-eslint");
-				importContent += 'import tseslint from "typescript-eslint";\n';
-			};
 
 			if (purpose === "problems") {
 				this.result.devDependencies.push("@eslint/js");
 				importContent += 'import js from "@eslint/js";\n';
-				let configContent = "";
-				if (useTs && !isTsConfigAdded) {
-					addTsDependencies();
-					configContent += `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended]`;
-					isTsConfigAdded = true;
-				} else {
-					configContent += `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended"]`;
-				}
+				// js/recommended needs to be quoted in the generated config file
+				const configs = useTs
+					? ['"js/recommended"', "tseslint.configs.recommended"]
+					: ['"js/recommended"'];
+				let configContent = `  { files: ["${extensions}"], plugins: { js }, extends: [${configs.join(", ")}]`;
 
 				const { config, importContent: envImport } =
 					addEnvironmentConfig({
@@ -239,13 +231,12 @@ export class ConfigGenerator {
 
 				exportContent += `  { files: ["${extensions}"], ${config} },\n`;
 			}
-			if (useTs && !isTsConfigAdded) {
-				addTsDependencies();
-				exportContent += "  tseslint.configs.recommended,\n";
-				/* eslint-disable-next-line no-useless-assignment -- ensure
-					code is extensible if isTsConfigAdded is later used
-				*/
-				isTsConfigAdded = true;
+			if (useTs) {
+				this.result.devDependencies.push("typescript-eslint");
+				importContent += 'import tseslint from "typescript-eslint";\n';
+				if (purpose !== "problems") {
+					exportContent += "  tseslint.configs.recommended,\n";
+				}
 			}
 
 			if (this.answers.framework === "vue") {

--- a/lib/config-generator.js
+++ b/lib/config-generator.js
@@ -189,11 +189,23 @@ export class ConfigGenerator {
 		// language = javascript/typescript
 		if (languages.includes("javascript")) {
 			const useTs = this.answers.useTs;
+			let isTsConfigAdded = false;
+			const addTsDependencies = () => {
+				this.result.devDependencies.push("typescript-eslint");
+				importContent += 'import tseslint from "typescript-eslint";\n';
+			};
 
 			if (purpose === "problems") {
 				this.result.devDependencies.push("@eslint/js");
 				importContent += 'import js from "@eslint/js";\n';
-				let configContent = `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended"]`;
+				let configContent = "";
+				if (useTs && !isTsConfigAdded) {
+					addTsDependencies();
+					configContent = `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended]`;
+					isTsConfigAdded = true;
+				} else {
+					configContent = `  { files: ["${extensions}"], plugins: { js }, extends: ["js/recommended"]`;
+				}
 
 				const { config, importContent: envImport } =
 					addEnvironmentConfig({
@@ -227,10 +239,10 @@ export class ConfigGenerator {
 
 				exportContent += `  { files: ["${extensions}"], ${config} },\n`;
 			}
-			if (useTs) {
-				this.result.devDependencies.push("typescript-eslint");
-				importContent += 'import tseslint from "typescript-eslint";\n';
+			if (useTs && !isTsConfigAdded) {
+				addTsDependencies();
 				exportContent += "  tseslint.configs.recommended,\n";
+				isTsConfigAdded = true;
 			}
 
 			if (this.answers.framework === "vue") {

--- a/tests/__snapshots__/cjs-configfile-js
+++ b/tests/__snapshots__/cjs-configfile-js
@@ -1,21 +1,20 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: globals.node } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  tseslint.configs.recommended,
 ]);
 ",
   "configFilename": "eslint.config.mjs",
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/cjs-configfile-js
+++ b/tests/__snapshots__/cjs-configfile-js
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
@@ -13,8 +13,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/cjs-configfile-ts
+++ b/tests/__snapshots__/cjs-configfile-ts
@@ -1,21 +1,20 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: globals.node } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  tseslint.configs.recommended,
 ]);
 ",
   "configFilename": "eslint.config.mts",
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/cjs-configfile-ts
+++ b/tests/__snapshots__/cjs-configfile-ts
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
@@ -13,8 +13,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/cjs-configfile-ts-jiti
+++ b/tests/__snapshots__/cjs-configfile-ts-jiti
@@ -1,21 +1,20 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: globals.node } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  tseslint.configs.recommended,
 ]);
 ",
   "configFilename": "eslint.config.mts",
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
     "jiti",
   ],
   "installFlags": [

--- a/tests/__snapshots__/cjs-configfile-ts-jiti
+++ b/tests/__snapshots__/cjs-configfile-ts-jiti
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
@@ -13,8 +13,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
     "jiti",
   ],
   "installFlags": [

--- a/tests/__snapshots__/esm-configfile-js
+++ b/tests/__snapshots__/esm-configfile-js
@@ -1,20 +1,19 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
-  tseslint.configs.recommended,
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: globals.node } },
 ]);
 ",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/esm-configfile-js
+++ b/tests/__snapshots__/esm-configfile-js
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
@@ -12,8 +12,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/esm-configfile-ts
+++ b/tests/__snapshots__/esm-configfile-ts
@@ -1,20 +1,19 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
-  tseslint.configs.recommended,
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: globals.node } },
 ]);
 ",
   "configFilename": "eslint.config.ts",
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/esm-configfile-ts
+++ b/tests/__snapshots__/esm-configfile-ts
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
@@ -12,8 +12,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/esm-configfile-ts-jiti
+++ b/tests/__snapshots__/esm-configfile-ts-jiti
@@ -1,20 +1,19 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: globals.node } },
-  tseslint.configs.recommended,
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: globals.node } },
 ]);
 ",
   "configFilename": "eslint.config.ts",
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
     "jiti",
   ],
   "installFlags": [

--- a/tests/__snapshots__/esm-configfile-ts-jiti
+++ b/tests/__snapshots__/esm-configfile-ts-jiti
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
@@ -12,8 +12,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
     "jiti",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -1,21 +1,20 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  tseslint.configs.recommended,
 ]);
 ",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/problems-commonjs-none-typescript
+++ b/tests/__snapshots__/problems-commonjs-none-typescript
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
@@ -13,8 +13,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
@@ -15,8 +15,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
     "eslint-plugin-react",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-commonjs-react-typescript
+++ b/tests/__snapshots__/problems-commonjs-react-typescript
@@ -1,14 +1,13 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);
 ",
@@ -16,8 +15,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
     "eslint-plugin-react",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
@@ -16,8 +16,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
     "eslint-plugin-vue",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-commonjs-vue-typescript
+++ b/tests/__snapshots__/problems-commonjs-vue-typescript
@@ -1,14 +1,13 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "commonjs" } },
-  tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
 ]);
@@ -17,8 +16,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
     "eslint-plugin-vue",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
@@ -12,8 +12,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/problems-esm-none-typescript
+++ b/tests/__snapshots__/problems-esm-none-typescript
@@ -1,20 +1,19 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  tseslint.configs.recommended,
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: {...globals.browser, ...globals.node} } },
 ]);
 ",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -1,13 +1,12 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  tseslint.configs.recommended,
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginReact.configs.flat.recommended,
 ]);
 ",
@@ -15,8 +14,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
     "eslint-plugin-react",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-esm-react-typescript
+++ b/tests/__snapshots__/problems-esm-react-typescript
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
@@ -14,8 +14,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
     "eslint-plugin-react",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -1,13 +1,12 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
-  tseslint.configs.recommended,
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
 ]);
@@ -16,8 +15,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
     "eslint-plugin-vue",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-esm-vue-typescript
+++ b/tests/__snapshots__/problems-esm-vue-typescript
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
@@ -15,8 +15,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
     "eslint-plugin-vue",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -1,21 +1,20 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  tseslint.configs.recommended,
 ]);
 ",
   "configFilename": "eslint.config.js",
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/problems-script-none-typescript
+++ b/tests/__snapshots__/problems-script-none-typescript
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
@@ -13,8 +13,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
   ],
   "installFlags": [
     "-D",

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -1,14 +1,13 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  tseslint.configs.recommended,
   pluginReact.configs.flat.recommended,
 ]);
 ",
@@ -16,8 +15,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
     "eslint-plugin-react",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-script-react-typescript
+++ b/tests/__snapshots__/problems-script-react-typescript
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
 import { defineConfig } from "eslint/config";
 
@@ -15,8 +15,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
     "eslint-plugin-react",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -1,7 +1,7 @@
 {
   "configContent": "import js from "@eslint/js";
-import tseslint from "typescript-eslint";
 import globals from "globals";
+import tseslint from "typescript-eslint";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
@@ -16,8 +16,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "typescript-eslint",
     "globals",
+    "typescript-eslint",
     "eslint-plugin-vue",
   ],
   "installFlags": [

--- a/tests/__snapshots__/problems-script-vue-typescript
+++ b/tests/__snapshots__/problems-script-vue-typescript
@@ -1,14 +1,13 @@
 {
   "configContent": "import js from "@eslint/js";
-import globals from "globals";
 import tseslint from "typescript-eslint";
+import globals from "globals";
 import pluginVue from "eslint-plugin-vue";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig([
-  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], plugins: { js }, extends: ["js/recommended"], languageOptions: { globals: {...globals.browser, ...globals.node} } },
+  { files: ["**/*.{js,mjs,cjs,ts,mts,cts,vue}"], plugins: { js }, extends: ["js/recommended", tseslint.configs.recommended], languageOptions: { globals: {...globals.browser, ...globals.node} } },
   { files: ["**/*.js"], languageOptions: { sourceType: "script" } },
-  tseslint.configs.recommended,
   pluginVue.configs["flat/essential"],
   { files: ["**/*.vue"], languageOptions: { parserOptions: { parser: tseslint.parser } } },
 ]);
@@ -17,8 +16,8 @@ export default defineConfig([
   "devDependencies": [
     "eslint",
     "@eslint/js",
-    "globals",
     "typescript-eslint",
+    "globals",
     "eslint-plugin-vue",
   ],
   "installFlags": [


### PR DESCRIPTION
<!--
    Thank you for contributing!

    ESLint adheres to the [OpenJS Foundation Code of Conduct](https://eslint.org/conduct).
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/eslint/.github/blob/master/CONTRIBUTING.md).

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (https://eslint.org/docs/latest/contribute/pull-requests)
    - Update or create tests
    - If performance-related, include a benchmark
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

#### AI acknowledgment

- [x] I did _not_ use AI to generate this PR.
- [ ] (If the above is not checked) I have reviewed the AI-generated content before submitting.

#### What is the purpose of this pull request?

Purpose of this PR is to lower the severity of `tseslint`'s recommended config for some CLI option-combinations.

Currently, `tseslint.configs.recommended` is added as a subsequent, separate config for any requested CLI options. This can unexpectedly override user-defined rules in previous (in terms of exported order) configs. 

While this may make sense for formatting configs like `eslint-config-prettier`, `tseslint`'s  docs add the `tseslint` config as part of the `extends` key, along other plugin configs like `js/recommended`.

#### What changes did you make? (Give an overview)

I tried to keep my changes minimal.

I moved `tseslint.configs.recommended` to the extends key only when:
- Linting JS files to find problems (CLI option)
- Linting TS files (CLI option)

For other CLI option-combinations, the generated `eslint.config` is left unchanged.

Vitest snapshot files were changed and reviewed accordingly.

#### Related Issues

<!-- include tags like "fixes #123" or "refs #123" -->

Related issue: https://github.com/eslint/create-config/issues/264

#### Is there anything you'd like reviewers to focus on?
